### PR TITLE
18960 - updated the cypress first auth fail test by asserting against the url

### DIFF
--- a/polaris-ui/.env.cypress
+++ b/polaris-ui/.env.cypress
@@ -12,4 +12,4 @@ REACT_APP_PIPELINE_POLLING_DELAY=100
 # Cypress is unhappy with the window.location.assign that happens in the
 # reauthentication flow, so we disable this. Not optimal, but e2e tests should
 # apply enough testing in this area.
-REACT_APP_REAUTH_REDIRECT_URL=
+REACT_APP_REAUTH_REDIRECT_URL="?q="

--- a/polaris-ui/.env.development.local.example
+++ b/polaris-ui/.env.development.local.example
@@ -7,3 +7,4 @@ REACT_APP_GATEWAY_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-polaris-dev-gateway/
 REACT_APP_MOCK_AUTH=false
 REACT_APP_MOCK_API_SOURCE=
 REACT_APP_MOCK_API_MAX_DELAY=2500
+REACT_APP_REAUTH_REDIRECT_URL="https://fa-polaris-dev-gateway.azurewebsites.net/polaris?q="

--- a/polaris-ui/cypress/e2e/auth.cy.ts
+++ b/polaris-ui/cypress/e2e/auth.cy.ts
@@ -1,17 +1,21 @@
 import { CASE_SEARCH_ROUTE } from "../../src/mock-api/routes";
 
 describe("Cms Authentication", () => {
-  it("can reathenticate if api returns 403", () => {
+  it("can reauthenticate if api returns 403", () => {
     cy.overrideRoute(CASE_SEARCH_ROUTE, {
       type: "break",
       httpStatusCode: 403,
     });
 
     cy.visit("/case-search-results?urn=12AB1111111");
-    cy.findByTestId("div-wait-reauth");
+    cy.location().should((location) => {
+      expect(location.href).to.eq(
+        "http://127.0.0.1:3000/case-search-results?q=http%3A%2F%2F127.0.0.1%3A3000%2Fcase-search-results%3Furn%3D12AB1111111%26auth-refresh"
+      );
+    });
   });
 
-  it("can throw if api returns 403 after Polaris has tried to reathenticate", () => {
+  it("can throw if api returns 403 after Polaris has tried to reauthenticate", () => {
     cy.overrideRoute(CASE_SEARCH_ROUTE, {
       type: "break",
       httpStatusCode: 403,

--- a/polaris-ui/src/app/features/cases/api/reauthentication-filter.ts
+++ b/polaris-ui/src/app/features/cases/api/reauthentication-filter.ts
@@ -9,7 +9,7 @@ const isCmsAuthFail = (response: Response) => response.status === 403;
 const isAuthPageLoad = (window: Window) =>
   window.location.href.includes(REAUTHENTICATION_INDICATOR_QUERY_PARAM);
 
-const tryCleanRefreshInidcator = (window: Window) => {
+const tryCleanRefreshIndicator = (window: Window) => {
   // clean the indicator from the browser address bar
   if (window.location.href.includes(REAUTHENTICATION_INDICATOR_QUERY_PARAM)) {
     const nextUrl = window.location.href.replace(
@@ -29,12 +29,7 @@ const tryHandleFirstAuthFail = (response: Response, window: Window) => {
       window.location.href + delimiter + REAUTHENTICATION_INDICATOR_QUERY_PARAM
     )}`;
 
-    // Cypress tests are unhappy with the window navigation during the failure flow.
-    //  For the time being, we let the test env file disable this step by setting
-    //  REAUTH_REDIRECT_URL to blank. Not optimal but this flow is tested by e2e tests.
-    if (REAUTH_REDIRECT_URL) {
-      window.location.href = nextUrl;
-    }
+    window.location.href = nextUrl;
     // stop any follow-on logic occurring
     throw new CmsAuthRedirectingError();
   }
@@ -43,14 +38,14 @@ const tryHandleFirstAuthFail = (response: Response, window: Window) => {
 
 const tryHandleSecondAuthFail = (response: Response, window: Window) => {
   if (isCmsAuthFail(response) && isAuthPageLoad(window)) {
-    tryCleanRefreshInidcator(window);
+    tryCleanRefreshIndicator(window);
     throw new CmsAuthError("We think you are not logged in to CMS");
   }
   return null;
 };
 
 const handleNonAuthCall = (response: Response, window: Window) => {
-  tryCleanRefreshInidcator(window);
+  tryCleanRefreshIndicator(window);
   return response;
 };
 


### PR DESCRIPTION
https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/18960

- updated the cypress test,
- added REACT_APP_REAUTH_REDIRECT_URL in env.local.example