### PR TITLE
Corrected the case of the expiryIndicator to match with the server data

### DIFF
--- a/polaris-ui/src/app/features/cases/domain/CaseDetails.ts
+++ b/polaris-ui/src/app/features/cases/domain/CaseDetails.ts
@@ -47,5 +47,5 @@ type Charge = {
 export type CustodyTimeLimit = {
   expiryDate: string;
   expiryDays: number;
-  expiryIndicator: "Active" | "Expired" | null;
+  expiryIndicator: "ACTIVE" | "EXPIRED" | null;
 };

--- a/polaris-ui/src/app/features/cases/presentation/case-details/accordion/Accordion.module.scss
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/accordion/Accordion.module.scss
@@ -119,6 +119,7 @@
   max-width: 80%;
   word-wrap: break-word;
   font-size: 16px;
+  text-align: left;
 }
 
 .accordion .accordion-document-date {

--- a/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.test.ts
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.test.ts
@@ -8,7 +8,7 @@ describe("getFormattedCustodyTimeData util", () => {
     };
     const result = getFormattedCustodyTimeData(custodyTimeLimit);
     const expectedResult = {
-      custodyExpiryDays: "EXPIRED",
+      custodyExpiryDays: "Expired",
       custodyExpiryDate: "20 Nov 2022",
     };
 

--- a/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.test.ts
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.test.ts
@@ -4,11 +4,11 @@ describe("getFormattedCustodyTimeData util", () => {
     const custodyTimeLimit = {
       expiryDate: "2022-11-20",
       expiryDays: 20,
-      expiryIndicator: "Expired" as const,
+      expiryIndicator: "EXPIRED" as const,
     };
     const result = getFormattedCustodyTimeData(custodyTimeLimit);
     const expectedResult = {
-      custodyExpiryDays: "Expired",
+      custodyExpiryDays: "EXPIRED",
       custodyExpiryDate: "20 Nov 2022",
     };
 
@@ -19,7 +19,7 @@ describe("getFormattedCustodyTimeData util", () => {
     const custodyTimeLimit = {
       expiryDate: "2022-11-20",
       expiryDays: 20,
-      expiryIndicator: "Active" as const,
+      expiryIndicator: "ACTIVE" as const,
     };
     const result = getFormattedCustodyTimeData(custodyTimeLimit);
     const expectedResult = {
@@ -33,7 +33,7 @@ describe("getFormattedCustodyTimeData util", () => {
     const custodyTimeLimit = {
       expiryDate: "2022-11-20",
       expiryDays: 1,
-      expiryIndicator: "Active" as const,
+      expiryIndicator: "ACTIVE" as const,
     };
     const result = getFormattedCustodyTimeData(custodyTimeLimit);
     const expectedResult = {
@@ -57,11 +57,6 @@ describe("getFormattedCustodyTimeData util", () => {
   });
 
   it("Should handle if the custodyTimeLimit is not available at all", () => {
-    const custodyTimeLimit = {
-      expiryDate: "2022-11-20",
-      expiryDays: 1,
-      expiryIndicator: null,
-    };
     const result = getFormattedCustodyTimeData(undefined as any);
     const expectedResult = {
       custodyExpiryDays: "N/A",

--- a/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.ts
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/utils/chargesUtil.ts
@@ -15,7 +15,7 @@ export const getFormattedCustodyTimeData = (
   const { expiryDate, expiryDays, expiryIndicator } = custodyTimeLimit;
 
   switch (expiryIndicator) {
-    case "Active":
+    case "ACTIVE":
       return {
         custodyExpiryDays: `${expiryDays} ${expiryDays > 1 ? "Days" : "Day"}`,
         custodyExpiryDate: formatDate(
@@ -24,7 +24,7 @@ export const getFormattedCustodyTimeData = (
         ),
       };
 
-    case "Expired":
+    case "EXPIRED":
       return {
         custodyExpiryDays: "Expired",
         custodyExpiryDate: formatDate(

--- a/polaris-ui/src/mock-api/data/caseDetails.cypress.ts
+++ b/polaris-ui/src/mock-api/data/caseDetails.cypress.ts
@@ -43,7 +43,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 20,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [],
       },
@@ -84,7 +84,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 20,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [],
       },
@@ -102,7 +102,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 120,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [],
       },
@@ -120,7 +120,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 180,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [],
       },
@@ -162,7 +162,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 20,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [
           {
@@ -178,7 +178,7 @@ const caseDetails: CaseDetails[] = [
             custodyTimeLimit: {
               expiryDate: "2022-11-20",
               expiryDays: 20,
-              expiryIndicator: "Active",
+              expiryIndicator: "ACTIVE",
             },
           },
           {
@@ -194,7 +194,7 @@ const caseDetails: CaseDetails[] = [
             custodyTimeLimit: {
               expiryDate: "2022-11-20",
               expiryDays: 20,
-              expiryIndicator: "Active",
+              expiryIndicator: "ACTIVE",
             },
           },
         ],

--- a/polaris-ui/src/mock-api/data/caseDetails.dev.ts
+++ b/polaris-ui/src/mock-api/data/caseDetails.dev.ts
@@ -43,7 +43,7 @@ const caseDetails: CaseDetails[] = [
         custodyTimeLimit: {
           expiryDate: "2022-11-20",
           expiryDays: 20,
-          expiryIndicator: "Active",
+          expiryIndicator: "ACTIVE",
         },
         charges: [],
       },


### PR DESCRIPTION
https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/19685

Bug:  The custody time limit is always showing N/A

Bug
<img width="399" alt="Screenshot 2023-03-09 at 09 17 17" src="https://user-images.githubusercontent.com/33631080/223976408-453c7a7c-10a9-495d-b04b-6fa5b1c22b73.png">

Bug fix - corrected the expiryIndicator text to Uppercase to match with the server data
<img width="379" alt="Screenshot 2023-03-09 at 09 17 33" src="https://user-images.githubusercontent.com/33631080/223976432-a6e11069-236d-4f92-b677-094edd7a2a50.png">
