### PR TITLE
Terraform: set app-insights connection string for UI plugin

### DIFF
--- a/polaris-terraform/ui-terraform/app-service.tf
+++ b/polaris-terraform/ui-terraform/app-service.tf
@@ -20,6 +20,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     "REACT_APP_GATEWAY_BASE_URL"               = ""
     "REACT_APP_GATEWAY_SCOPE"                  = "https://CPSGOVUK.onmicrosoft.com/${azurerm_linux_function_app.fa_polaris.name}/user_impersonation"
     "REACT_APP_REAUTH_REDIRECT_URL"            = "/polaris?polaris-ui-url="
+    "REACT_APP_AI_CONNECTION_STRING"           = data.azurerm_application_insights.global_ai.connection_string
   }
 
   site_config {


### PR DESCRIPTION
Set env-specific app-insights connection string for dynamic injection per-environment via subsitute-config.js