### PR TITLE
bugfix/tracker-404

### DIFF
--- a/polaris-ui/src/app/features/cases/api/gateway-api.ts
+++ b/polaris-ui/src/app/features/cases/api/gateway-api.ts
@@ -128,7 +128,7 @@ export const initiatePipeline = async (urn: string, caseId: number) => {
 export const getPipelinePdfResults = async (
   trackerUrl: string,
   existingCorrelationId: string
-) => {
+): Promise<false | PipelineResults> => {
   const headers = await buildHeaders(
     HEADERS.correlationId(existingCorrelationId),
     HEADERS.auth
@@ -137,7 +137,10 @@ export const getPipelinePdfResults = async (
   const response = await internalFetch(trackerUrl, {
     headers,
   });
-
+  // we are ignoring the tracker status 404 as it is an expected one and continue polling
+  if (response.status === 404) {
+    return false;
+  }
   const rawResponse: { documents: any[] } = await response.json();
   const { documents } = rawResponse;
   temporaryApiModelMapping(documents);
@@ -159,7 +162,6 @@ export const getPipelinePdfResults = async (
 
   return rawResponse as PipelineResults;
 };
-
 export const searchCase = async (
   urn: string,
   caseId: number,

--- a/polaris-ui/src/app/features/cases/hooks/use-pipeline-api/initiate-and-poll.ts
+++ b/polaris-ui/src/app/features/cases/hooks/use-pipeline-api/initiate-and-poll.ts
@@ -106,8 +106,9 @@ export const initiateAndPoll = (
           trackerArgs.trackerUrl,
           trackerArgs.correlationId
         );
-
-        handleApiCallSuccess(pipelineResult);
+        if (pipelineResult) {
+          handleApiCallSuccess(pipelineResult);
+        }
       } catch (error) {
         handleApiCallError(error);
       }


### PR DESCRIPTION
Ignoring the tracker 404 status as it is an expected one during the pipeline refresh process