### PR TITLE
add rate limiting to CMS requests

### DIFF
--- a/polaris-terraform/ui-terraform/nginx.conf
+++ b/polaris-terraform/ui-terraform/nginx.conf
@@ -10,6 +10,8 @@ events {
 }
 
 http {
+  limit_req_zone cms zone=cms:1m rate=${CMS_RATE_LIMIT};
+  limit_req_status 429;
   js_import templates/nginx.js;
   access_log  /dev/stdout;
 
@@ -66,6 +68,9 @@ http {
 
     # CMS UI traffic
     location /CMS.20.0.04 {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
+    
       # IE Mode Desired
       if ( $ieaction = 'nonie+nonconfigurable+') {
         return 402 'requires Internet Explorer mode';
@@ -93,6 +98,9 @@ http {
     }
 
     location /CMS.20.0.04/Case/uacdCDTabs.aspx {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
+
       sub_filter_types *;
       sub_filter_once off;
       sub_filter ${UPSTREAM_CMS_DOMAIN_NAME} $host;
@@ -115,6 +123,8 @@ http {
 
     # At development time it is useful to have a path through to CMS Modern
     location / {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
 
       sub_filter_once off;
       sub_filter_types *;
@@ -137,8 +147,9 @@ http {
     }
 
     location /ajax/viewer/ {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
 
-      add_header X-InternetExplorerMode 0;
       sub_filter_once off;
       sub_filter_types *;
       sub_filter_types text/xml text/css text/javascript;
@@ -215,6 +226,9 @@ http {
 
     # internal-only route to CMS Classic, used by DDEI
     location /internal-implementation/CMS.20.0.04/ {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
+
       sub_filter_once off;
       sub_filter ${UPSTREAM_CMS_IP} $host;
       sub_filter ${UPSTREAM_CMS_DOMAIN_NAME} $host;
@@ -229,6 +243,9 @@ http {
 
     # internal-only route to CMS Modern, used by DDEI
     location /internal-implementation/modern/ {
+      limit_req zone=cms burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
+
       proxy_redirect     off;
       proxy_ssl_server_name on;
       proxy_ssl_session_reuse off;

--- a/polaris-terraform/ui-terraform/proxy-service-plan.tf
+++ b/polaris-terraform/ui-terraform/proxy-service-plan.tf
@@ -20,7 +20,7 @@ resource "azurerm_monitor_autoscale_setting" "amas_polaris_proxy" {
     capacity {
       default = 1
       minimum = 1
-      maximum = 10
+      maximum = 1
     }
     rule {
       metric_trigger {

--- a/polaris-terraform/ui-terraform/proxy.tf
+++ b/polaris-terraform/ui-terraform/proxy.tf
@@ -41,6 +41,8 @@ resource "azurerm_linux_web_app" "polaris_proxy" {
     "DOCKER_REGISTRY_SERVER_PASSWORD"                 = data.azurerm_container_registry.polaris_container_registry.admin_password
     "NGINX_ENVSUBST_OUTPUT_DIR"                       = "/etc/nginx"
     "FORCE_REFRESH_CONFIG"                            = "${md5(file("nginx.conf"))}:${md5(file("nginx.js"))}"
+    "CMS_RATE_LIMIT_QUEUE"                            = "100000000000000000"
+    "CMS_RATE_LIMIT"                                  = "1024r/s"
   }
 
   site_config {


### PR DESCRIPTION
this PR uses the nginx [ngx_http_limit_req](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html) rate limiting module for all requests to CMS, keyed by `cms` meaning that they are all in the same pot between modern, classic and also the user facing proxy.
Ultimately this serves to limit the number of requests we can send over the wire to CMS currently to `1024` requests a second (configurable by app setting var, see terraform).

Important things to note:
- This limit is per-instance of nginx, it doesn't distribute awareness at all, so I've currently set the maximum number of instances to `1`, at some point for resilience we'll likely want a fixed instance count of 2 or 3, at which point we'll want to divide the number of requests a second by the instance count. nginx is super light weight, so its unlikely to ever want to scale unless something is very wrong.
- There is a queue limit, currently set to the biggest number nginx would allow `100000000000000000` this basically means once you saturate the request a second limit, then it'll queue up to that number of requests before responding with 429 errors.
- Azure limits requests to needing to complete within `230s` so if its really hammered azure might timeout and the request will get dropped from the queue before it executes/completes. If azure times out, it'll respond with a `503`
- All responses have an added `x-limit-req-status` HTTP response header which will be one of:
  - ` PASSED` - request was completed below request/second threshold
  - `DELAYED` - request was delayed because of threshold. Applications might like to observe this and slow down, or time-shift non-essential requests)
  - `REJECTED` - request was rejected (status code `429`) because the queue is full. similar to delayed, applications are free to retry, though may want to slow down, or time-shift.
  - ~`DELAYED_DRY_RUN`~ ~ not used since no dry run configured
  - ~`REJECTED_DRY_RUN`~ not used since no dry run configured