### PR TITLE
Feature/21774 improve diff checks using tags

### DIFF
--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-build-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-build-pipeline.yml
@@ -23,7 +23,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/coordinator/coordinator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Coordinator package to publish"
 
@@ -51,7 +51,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/pdf-generator/pdf-generator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create PDF-Generator package to publish"
 
@@ -66,7 +66,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/text-extractor/text-extractor.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Text-Extractor package to publish"
 
@@ -81,7 +81,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Auth Handover package to publish"
 
@@ -96,7 +96,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Gateway package to publish"
 
@@ -122,7 +122,7 @@ stages:
               workingDirectory: polaris-ui/public
               script: |
                 New-Item build-version.txt
-                Set-Content build-version.txt '$(Build.BuildNumber)'
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)'
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -283,31 +283,10 @@ stages:
                 git push origin --tags 
             displayName: Updating the dev tag
             
-  - stage: Run_e2e_Tests_DEV
-    displayName: Run e2e tests > DEV
-    dependsOn:
-      - Apply_DEV
-      - Check_DEV
-      - Update_DEV_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_DEV
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: DEV'
-            inputs:
-              buildDefinition: 129
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
-          
   - stage: Apply_QA
     displayName: Deployment > QA
     dependsOn:
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -565,31 +544,10 @@ stages:
                 git push origin --tags 
             displayName: Updating the qa tag
             
-  - stage: Run_e2e_Tests_QA
-    displayName: Run e2e tests > QA
-    dependsOn:
-      - Apply_QA
-      - Check_QA
-      - Update_QA_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_QA
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: QA'
-            inputs:
-              buildDefinition: 210
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
-          
   - stage: Apply_PROD
     displayName: Deployment > PROD
     dependsOn:
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -254,6 +254,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -263,7 +266,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
 
@@ -511,6 +514,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -520,7 +526,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
 
@@ -768,6 +774,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -777,7 +786,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD"
             displayName: "Publish Commit report for PROD"
 

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -29,7 +29,7 @@ stages:
     pool:
       name: $(dev-build-agent)
     jobs:
-      - deployment: Manual_Codebase_Deployment
+      - deployment: Manual_Deploy_Polaris_Codebase
         environment: "DEV"
         strategy:
           runOnce:
@@ -76,6 +76,20 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-dev-text-extractor"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-text-extractor-drop
+                    
+                #download UI build artifact
+                - download: PolarisManualCodebaseOnlyBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to DEV'
+                  inputs:
+                    azureSubscription: $(dev-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-dev"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualCodebaseOnlyBuild
@@ -104,20 +118,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualCodebaseOnlyBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to DEV'
-                  inputs:
-                    azureSubscription: $(dev-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-dev"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -245,14 +245,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Check_DEV
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log dev...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-dev.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV"
+            displayName: "Publish Commit report for DEV"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+
+                git push origin :refs/tags/dev
+                git tag -f dev
+                git tag -f $(resources.pipeline.PolarisManualCodebaseOnlyBuild.runName)
+                git push origin --tags 
+            displayName: Updating the dev tag
           
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Check_DEV
+    dependsOn: Update_DEV_Tag
     pool:
       name: $(qa-build-agent)
     jobs:
-      - deployment: Manual_Codebase_Deployment
+      - deployment: Manual_Deploy_Polaris_Codebase
         environment: "QA"
         strategy:
           runOnce:
@@ -299,6 +333,20 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-qa-text-extractor"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-text-extractor-drop
+                    
+                #download UI build artifact
+                - download: PolarisManualCodebaseOnlyBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+                    
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to QA'
+                  inputs:
+                    azureSubscription: $(qa-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-qa"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
 
                 #download gateway build artifact
                 - download: PolarisManualCodebaseOnlyBuild
@@ -328,20 +376,6 @@ stages:
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-auth-handover-drop
 
-                #download UI build artifact
-                - download: PolarisManualCodebaseOnlyBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to QA'
-                  inputs:
-                    azureSubscription: $(qa-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-qa"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
-
                 # Restart app service    
                 - task: AzureAppServiceManage@0
                   displayName: 'Restart Azure App Service'
@@ -349,7 +383,7 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     Action: 'Restart Azure App Service'
                     WebAppName: "as-web-polaris-qa"
-                    
+  
   - stage: Check_QA
     displayName: Status Check > QA
     dependsOn:
@@ -468,14 +502,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Check_QA
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log qa...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-qa.csv
+            displayName: Generate commit report for QA
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              artifact: "Commit Report - QA"
+            displayName: "Publish Commit report for QA"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/qa
+                git tag -f qa
+                git tag -f $(resources.pipeline.PolarisManualCodebaseOnlyBuild.runName)
+                git push origin --tags 
+            displayName: Updating the qa tag
           
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Check_QA
+    dependsOn: Update_QA_Tag
     pool:
       name: $(prod-build-agent)
     jobs:
-      - deployment: Manual_Codebase_Deployment
+      - deployment: Manual_Deploy_Polaris_Codebase
         environment: "Prod"
         strategy:
           runOnce:
@@ -522,6 +590,20 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-text-extractor"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-text-extractor-drop
+                    
+                #download UI build artifact
+                - download: PolarisManualCodebaseOnlyBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to PROD'
+                  inputs:
+                    azureSubscription: $(prod-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
 
                 #download gateway build artifact
                 - download: PolarisManualCodebaseOnlyBuild
@@ -550,20 +632,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-auth-handover-drop
-
-                #download UI build artifact
-                - download: PolarisManualCodebaseOnlyBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to PROD'
-                  inputs:
-                    azureSubscription: $(prod-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualCodebaseOnlyBuild/polaris-ui-drop
 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -691,3 +759,37 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Check_PROD
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for PROD
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/prod
+                git tag -f prod
+                git tag -f $(resources.pipeline.PolarisManualCodebaseOnlyBuild.runName)
+                git push origin --tags 
+            displayName: Updating the prod tag

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -282,10 +282,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualCodebaseOnlyBuild.runName)
                 git push origin --tags 
             displayName: Updating the dev tag
+            
+  - stage: Run_e2e_Tests_DEV
+    displayName: Run e2e tests > DEV
+    dependsOn:
+      - Apply_DEV
+      - Check_DEV
+      - Update_DEV_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_DEV
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: DEV'
+            inputs:
+              buildDefinition: 129
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
           
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Update_DEV_Tag
+    dependsOn:
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -542,10 +564,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualCodebaseOnlyBuild.runName)
                 git push origin --tags 
             displayName: Updating the qa tag
+            
+  - stage: Run_e2e_Tests_QA
+    displayName: Run e2e tests > QA
+    dependsOn:
+      - Apply_QA
+      - Check_QA
+      - Update_QA_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_QA
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: QA'
+            inputs:
+              buildDefinition: 210
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
           
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Update_QA_Tag
+    dependsOn:
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-build-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-build-pipeline.yml
@@ -51,7 +51,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/coordinator/coordinator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Coordinator package to publish"
 
@@ -79,7 +79,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/pdf-generator/pdf-generator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create PDF-Generator package to publish"
 
@@ -94,7 +94,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/text-extractor/text-extractor.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Text-Extractor package to publish"
 
@@ -109,7 +109,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Auth Handover package to publish"
 
@@ -124,7 +124,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Gateway package to publish"
 
@@ -150,7 +150,7 @@ stages:
               workingDirectory: polaris-ui/public
               script: |
                 New-Item build-version.txt
-                Set-Content build-version.txt '$(Build.BuildNumber)'
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)'
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -468,10 +468,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualTerraformBuild.runName)
                 git push origin --tags 
             displayName: Updating the dev tag
+            
+  - stage: Run_e2e_Tests_DEV
+    displayName: Run e2e tests > DEV
+    dependsOn:
+      - Apply_DEV
+      - Check_DEV
+      - Update_DEV_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_DEV
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: DEV'
+            inputs:
+              buildDefinition: 129
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
                     
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Update_DEV_Tag
+    dependsOn: 
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -914,10 +936,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualTerraformBuild.runName)
                 git push origin --tags 
             displayName: Updating the qa tag
+            
+  - stage: Run_e2e_Tests_QA
+    displayName: Run e2e tests > QA
+    dependsOn:
+      - Apply_QA
+      - Check_QA
+      - Update_QA_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_QA
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: QA'
+            inputs:
+              buildDefinition: 210
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
                     
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Update_QA_Tag
+    dependsOn:
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -29,7 +29,7 @@ stages:
     pool:
       name: $(dev-build-agent)
     jobs:
-      - deployment: Manual_Full_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_FullTerraform
         environment: "DEV"
         strategy:
           runOnce:
@@ -262,6 +262,20 @@ stages:
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
                     TF_LOG: $(dev-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisManualTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to DEV'
+                  inputs:
+                    azureSubscription: $(dev-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-dev"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualTerraformBuild
@@ -290,20 +304,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to DEV'
-                  inputs:
-                    azureSubscription: $(dev-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-dev"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -431,14 +431,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Check_DEV
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log dev...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-dev.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV"
+            displayName: "Publish Commit report for DEV"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/dev
+                git tag -f dev
+                git tag -f $(resources.pipeline.PolarisManualTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the dev tag
                     
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Check_DEV
+    dependsOn: Update_DEV_Tag
     pool:
       name: $(qa-build-agent)
     jobs:
-      - deployment: Manual_Full_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_FullTerraform
         environment: "QA"
         strategy:
           runOnce:
@@ -670,7 +704,21 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
-                    TF_LOG: $(qa-log-level)
+                    TF_LOG: 
+                      
+                #download UI build artifact
+                - download: PolarisManualTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to QA'
+                  inputs:
+                    azureSubscription: $(qa-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-qa"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualTerraformBuild
@@ -699,20 +747,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to QA'
-                  inputs:
-                    azureSubscription: $(qa-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-qa"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -840,14 +874,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Check_QA
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log qa...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-qa.csv
+            displayName: Generate commit report for QA
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              artifact: "Commit Report - QA"
+            displayName: "Publish Commit report for QA"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/qa
+                git tag -f qa
+                git tag -f $(resources.pipeline.PolarisManualTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the qa tag
                     
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Check_QA
+    dependsOn: Update_QA_Tag
     pool:
       name: $(prod-build-agent)
     jobs:
-      - deployment: Manual_Full_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_FullTerraform
         environment: "Prod"
         strategy:
           runOnce:
@@ -1080,6 +1148,20 @@ stages:
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
                     TF_LOG: $(prod-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisManualTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to PROD'
+                  inputs:
+                    azureSubscription: $(prod-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
 
                 #download gateway build artifact
                 - download: PolarisManualTerraformBuild
@@ -1108,20 +1190,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
-
-                #download UI build artifact
-                - download: PolarisManualTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to PROD'
-                  inputs:
-                    azureSubscription: $(prod-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-ui-drop
 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -1249,3 +1317,37 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Check_PROD
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for PROD
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/prod
+                git tag -f prod
+                git tag -f $(resources.pipeline.PolarisManualTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the prod tag

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -469,31 +469,10 @@ stages:
                 git push origin --tags 
             displayName: Updating the dev tag
             
-  - stage: Run_e2e_Tests_DEV
-    displayName: Run e2e tests > DEV
-    dependsOn:
-      - Apply_DEV
-      - Check_DEV
-      - Update_DEV_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_DEV
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: DEV'
-            inputs:
-              buildDefinition: 129
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
-                    
   - stage: Apply_QA
     displayName: Deployment > QA
     dependsOn: 
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -937,31 +916,10 @@ stages:
                 git push origin --tags 
             displayName: Updating the qa tag
             
-  - stage: Run_e2e_Tests_QA
-    displayName: Run e2e tests > QA
-    dependsOn:
-      - Apply_QA
-      - Check_QA
-      - Update_QA_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_QA
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: QA'
-            inputs:
-              buildDefinition: 210
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
-                    
   - stage: Apply_PROD
     displayName: Deployment > PROD
     dependsOn:
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -440,6 +440,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -449,7 +452,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
 
@@ -883,6 +886,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -892,7 +898,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
 
@@ -1326,6 +1332,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1335,7 +1344,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD"
             displayName: "Publish Commit report for PROD"
 

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-build-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-build-pipeline.yml
@@ -37,7 +37,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Auth Handover package to publish"
 
@@ -52,7 +52,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Gateway package to publish"
 
@@ -78,7 +78,7 @@ stages:
               workingDirectory: polaris-ui/public
               script: |
                 New-Item build-version.txt
-                Set-Content build-version.txt '$(Build.BuildNumber)'
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)'
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -337,31 +337,10 @@ stages:
                 git push origin --tags 
             displayName: Updating the dev tag
             
-  - stage: Run_e2e_Tests_DEV
-    displayName: Run e2e tests > DEV
-    dependsOn:
-      - Apply_DEV
-      - Check_DEV
-      - Update_DEV_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_DEV
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: DEV'
-            inputs:
-              buildDefinition: 129
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
-                    
   - stage: Apply_QA
     displayName: Deployment > QA
     dependsOn: 
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -672,32 +651,11 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
                 git push origin --tags 
             displayName: Updating the qa tag
-            
-  - stage: Run_e2e_Tests_QA
-    displayName: Run e2e tests > QA
-    dependsOn:
-      - Apply_QA
-      - Check_QA
-      - Update_QA_Tag
-    condition: succeeded()
-    jobs:
-      - job: Run_e2e_Tests_QA
-        pool:
-          vmImage: windows-latest
-        steps:
-          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests: QA'
-            inputs:
-              buildDefinition: 210
-              waitForQueuedBuildsToFinish: true
-              cancelBuildsIfAnyFails: true
-              password: $(devops-pat-token)
                     
   - stage: Apply_PROD
     displayName: Deployment > PROD
     dependsOn:
       - Update_DEV_Tag
-      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -336,10 +336,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
                 git push origin --tags 
             displayName: Updating the dev tag
+            
+  - stage: Run_e2e_Tests_DEV
+    displayName: Run e2e tests > DEV
+    dependsOn:
+      - Apply_DEV
+      - Check_DEV
+      - Update_DEV_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_DEV
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: DEV'
+            inputs:
+              buildDefinition: 129
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
                     
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Update_DEV_Tag
+    dependsOn: 
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -650,10 +672,32 @@ stages:
                 git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
                 git push origin --tags 
             displayName: Updating the qa tag
+            
+  - stage: Run_e2e_Tests_QA
+    displayName: Run e2e tests > QA
+    dependsOn:
+      - Apply_QA
+      - Check_QA
+      - Update_QA_Tag
+    condition: succeeded()
+    jobs:
+      - job: Run_e2e_Tests_QA
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: QA'
+            inputs:
+              buildDefinition: 210
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
                     
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Update_QA_Tag
+    dependsOn:
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     pool:
       name: $(prod-build-agent)
     jobs:

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -308,6 +308,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -317,7 +320,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
 
@@ -619,6 +622,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -628,7 +634,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
 
@@ -930,6 +936,9 @@ stages:
         pool:
           vmImage: ubuntu-latest
         steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -939,7 +948,7 @@ stages:
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD"
             displayName: "Publish Commit report for PROD"
 

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -29,7 +29,7 @@ stages:
     pool:
       name: $(dev-build-agent)
     jobs:
-      - deployment: Manual_UI_Only_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_UITerraform
         environment: "DEV"
         strategy:
           runOnce:
@@ -130,6 +130,20 @@ stages:
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
                     TF_LOG: $(dev-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisManualUIOnlyTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to DEV'
+                  inputs:
+                    azureSubscription: $(dev-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-dev"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualUIOnlyTerraformBuild
@@ -158,20 +172,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualUIOnlyTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to DEV'
-                  inputs:
-                    azureSubscription: $(dev-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-dev"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -299,14 +299,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Check_DEV
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log dev...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-dev.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV"
+            displayName: "Publish Commit report for DEV"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/dev
+                git tag -f dev
+                git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the dev tag
                     
   - stage: Apply_QA
     displayName: Deployment > QA
-    dependsOn: Check_DEV
+    dependsOn: Update_DEV_Tag
     pool:
       name: $(qa-build-agent)
     jobs:
-      - deployment: Manual_UI_Only_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_UITerraform
         environment: "QA"
         strategy:
           runOnce:
@@ -407,6 +441,20 @@ stages:
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
                     TF_LOG: $(qa-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisManualUIOnlyTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to QA'
+                  inputs:
+                    azureSubscription: $(qa-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-qa"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualUIOnlyTerraformBuild
@@ -435,20 +483,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualUIOnlyTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to QA'
-                  inputs:
-                    azureSubscription: $(qa-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-qa"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -576,14 +610,48 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Check_QA
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log qa...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-qa.csv
+            displayName: Generate commit report for QA
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-qa.csv"
+              artifact: "Commit Report - QA"
+            displayName: "Publish Commit report for QA"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/qa
+                git tag -f qa
+                git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the qa tag
                     
   - stage: Apply_PROD
     displayName: Deployment > PROD
-    dependsOn: Check_QA
+    dependsOn: Update_QA_Tag
     pool:
       name: $(prod-build-agent)
     jobs:
-      - deployment: Manual_UI_Only_Terraform_Deployment
+      - deployment: Manual_Deploy_Polaris_UITerraform
         environment: "Prod"
         strategy:
           runOnce:
@@ -684,6 +752,20 @@ stages:
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
                     TF_LOG: $(prod-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisManualUIOnlyTerraformBuild
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  displayName: 'Deploy UI App Service to PROD'
+                  inputs:
+                    azureSubscription: $(prod-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 #download gateway build artifact
                 - download: PolarisManualUIOnlyTerraformBuild
@@ -712,20 +794,6 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisManualUIOnlyTerraformBuild
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  displayName: 'Deploy UI App Service to PROD'
-                  inputs:
-                    azureSubscription: $(prod-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-ui-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -853,3 +921,37 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Check_PROD
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for PROD
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.SourcesDirectory)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/prod
+                git tag -f prod
+                git tag -f $(resources.pipeline.PolarisManualUIOnlyTerraformBuild.runName)
+                git push origin --tags 
+            displayName: Updating the prod tag

--- a/polaris-devops-pipelines/polaris-build-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-build-pipeline.yml
@@ -36,7 +36,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                $files = $(git diff --name-only --relative --diff-filter AMR HEAD^ HEAD)
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
                 $temp=$files -split ' '
                 $count=$temp.Length
                 echo "Total changed $count files"
@@ -48,102 +48,324 @@ stages:
                   if ($name -like 'polaris-terraform/pipeline-terraform/*')
                   {
                     echo "run pipeline terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
                   {
                     echo "run pipeline events terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-terraform/ui-terraform/*')
                   {
                     echo "run ui terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"                    
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"                    
                   }
                   if ($name -like 'polaris-terraform/ui-events-terraform/*')
                   {
                     echo "run ui events terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/*')
                   {
                     echo "run pipeline codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/coordinator/*')
                   {
                     echo "run coordinator..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/pdf-generator/*')
                   {
                     echo "run pdf generator..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/text-extractor/*')
                   {
                     echo "run text extractor..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/*')
                   {
                     echo "run gateway codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-gateway/*')
                   {
                     echo "run gateway..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-auth-handover/*')
                   {
                     echo "run auth handover..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-ui/*')
                   {
                     echo "run ui codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/DdeiClient/*')
                   {
                     echo "changes to DdeiClient detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/Common/*')
                   {
                     echo "changes to the Pipeline's Common library detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-gateway.common/*')
                   {
                     echo "changes to the Gateway's Common library detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                  }
+                }
+                
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
+                $temp=$files -split ' '
+                $count=$temp.Length
+                echo "Total changed $count files"
+
+                For ($i=0; $i -lt $temp.Length; $i++)
+                {
+                  $name=$temp[$i]
+                  echo "this is $name file"
+                  if ($name -like 'polaris-terraform/pipeline-terraform/*')
+                  {
+                    echo "run pipeline terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
+                  {
+                    echo "run pipeline events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/ui-terraform/*')
+                  {
+                    echo "run ui terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"                    
+                  }
+                  if ($name -like 'polaris-terraform/ui-events-terraform/*')
+                  {
+                    echo "run ui events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/*')
+                  {
+                    echo "run pipeline codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/coordinator/*')
+                  {
+                    echo "run coordinator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/pdf-generator/*')
+                  {
+                    echo "run pdf generator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/text-extractor/*')
+                  {
+                    echo "run text extractor..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/*')
+                  {
+                    echo "run gateway codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway/*')
+                  {
+                    echo "run gateway..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-auth-handover/*')
+                  {
+                    echo "run auth handover..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-ui/*')
+                  {
+                    echo "run ui codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/DdeiClient/*')
+                  {
+                    echo "changes to DdeiClient detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/Common/*')
+                  {
+                    echo "changes to the Pipeline's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway.common/*')
+                  {
+                    echo "changes to the Gateway's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                }
+                
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
+                $temp=$files -split ' '
+                $count=$temp.Length
+                echo "Total changed $count files"
+
+                For ($i=0; $i -lt $temp.Length; $i++)
+                {
+                  $name=$temp[$i]
+                  echo "this is $name file"
+                  if ($name -like 'polaris-terraform/pipeline-terraform/*')
+                  {
+                    echo "run pipeline terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
+                  {
+                    echo "run pipeline events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/ui-terraform/*')
+                  {
+                    echo "run ui terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"                    
+                  }
+                  if ($name -like 'polaris-terraform/ui-events-terraform/*')
+                  {
+                    echo "run ui events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/*')
+                  {
+                    echo "run pipeline codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/coordinator/*')
+                  {
+                    echo "run coordinator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/pdf-generator/*')
+                  {
+                    echo "run pdf generator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/text-extractor/*')
+                  {
+                    echo "run text extractor..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/*')
+                  {
+                    echo "run gateway codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway/*')
+                  {
+                    echo "run gateway..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-auth-handover/*')
+                  {
+                    echo "run auth handover..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-ui/*')
+                  {
+                    echo "run ui codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/DdeiClient/*')
+                  {
+                    echo "changes to DdeiClient detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/Common/*')
+                  {
+                    echo "changes to the Pipeline's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway.common/*')
+                  {
+                    echo "changes to the Gateway's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
                   }
                 }
             name: Change_Results
@@ -152,53 +374,92 @@ stages:
   - stage: Publish_Artifacts
     displayName: Publish artifacts
     dependsOn: Determine_Changes
-    condition: and(succeeded(), or(eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_PIPELINE_TERRAFORM'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_UI_TERRAFORM'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_UI_EVENTS_TERRAFORM'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_PIPELINE_CODEBASE'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_GATEWAY_CODEBASE'], 'true'),eq(dependencies.Determine_Changes.outputs['Generate_Diff.Change_Results.RUN_UI_CODEBASE'], 'true')))
+    condition: succeeded()
     variables:
-      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM']]
-      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
-      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM']]
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
+      runPipelineTerraformDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_DEV']]
+      runPipelineEventsTerraformDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_DEV']]
+      runUITerraformDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_DEV']]
+      runUIEventsTerraformDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_DEV']]
+      runCoordinatorDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_DEV']]
+      runPdfGeneratorDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_DEV']]
+      runTextExtractorDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_DEV']]
+      runGatewayDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_DEV']]
+      runAuthHandoverDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_DEV']]
+      runUICodebaseDEV: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_DEV']]
+      
+      runPipelineTerraformQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_QA']]
+      runPipelineEventsTerraformQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_QA']]
+      runUITerraformQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_QA']]
+      runUIEventsTerraformQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_QA']]
+      runCoordinatorQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_QA']]
+      runPdfGeneratorQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_QA']]
+      runTextExtractorQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_QA']]
+      runGatewayQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_QA']]
+      runAuthHandoverQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_QA']]
+      runUICodebaseQA: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_QA']]
+      
+      runPipelineTerraformPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_PROD']]
+      runPipelineEventsTerraformPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_PROD']]
+      runUITerraformPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_PROD']]
+      runUIEventsTerraformPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_PROD']]
+      runCoordinatorPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_PROD']]
+      runPdfGeneratorPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_PROD']]
+      runTextExtractorPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_PROD']]
+      runGatewayPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_PROD']]
+      runAuthHandoverPROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_PROD']]
+      runUICodebasePROD: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_PROD']]
     jobs:
-      - job:
+      - job: Build_GLOBAL_Artifacts
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PublishPipelineArtifact@1
+            displayName: "Publish pipeline scripts"
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-ddei-devops-pipelines/scripts"
+              artifact: "ddei-script-files"
+              publishLocation: "pipeline"
+              
+          - task: DownloadSecureFile@1
+            name: licence
+            inputs:
+              secureFile: 'Aspose.Total.NET.lic'
+            displayName: 'Download Aspose Licence'
+              
+      - job: Build_DEV_Artifacts
         pool:
           vmImage: ubuntu-latest
         steps:
           - task: PublishPipelineArtifact@1
             displayName: 'Publish pipeline terraform artifact'
-            condition: eq(variables.runPipelineTerraform, 'true')
+            condition: eq(variables.runPipelineTerraformDEV, 'true')
             inputs:
               targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-terraform/"
-              artifact: "pipeline-terraform-files"
+              artifact: "pipeline-terraform-files-dev"
               publishLocation: "pipeline"
 
           - task: PublishPipelineArtifact@1
             displayName: 'Publish pipeline events terraform artifact'
-            condition: eq(variables.runPipelineEventsTerraform, 'true')
+            condition: eq(variables.runPipelineEventsTerraformDEV, 'true')
             inputs:
               targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-events-terraform/"
-              artifact: "pipeline-events-terraform-files"
+              artifact: "pipeline-events-terraform-files-dev"
               publishLocation: "pipeline"
               
           - task: PublishPipelineArtifact@1
             displayName: 'Publish UI terraform artifact'
-            condition: eq(variables.runUITerraform, 'true')
+            condition: eq(variables.runUITerraformDEV, 'true')
             inputs:
               targetPath: '$(Pipeline.Workspace)/s/polaris-terraform/ui-terraform/'
-              artifact: 'ui-terraform-files'
+              artifact: 'ui-terraform-files-dev'
               publishLocation: 'pipeline'
               
           - task: PublishPipelineArtifact@1
             displayName: 'Publish UI events terraform artifact'
-            condition: eq(variables.runUIEventsTerraform, 'true')
+            condition: eq(variables.runUIEventsTerraformDEV, 'true')
             inputs:
               targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/ui-events-terraform/"
-              artifact: "ui-events-terraform-files"
+              artifact: "ui-events-terraform-files-dev"
               publishLocation: "pipeline"
   
           - task: DotNetCoreCLI@2
@@ -206,49 +467,43 @@ stages:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/coordinator/coordinator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Coordinator package to publish"
-            condition: eq(variables.runCoordinator, 'true')
+            condition: eq(variables.runCoordinatorDEV, 'true')
 
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.ArtifactStagingDirectory)/coordinator"
-              artifact: "polaris-coordinator-drop"
+              artifact: "polaris-coordinator-dev-drop"
             displayName: "Publish Coordinator codebase artifact"
-            condition: eq(variables.runCoordinator, 'true')
+            condition: eq(variables.runCoordinatorDEV, 'true')
             
-          - task: DownloadSecureFile@1
-            name: licence
-            inputs:
-              secureFile: 'Aspose.Total.NET.lic'
-            displayName: 'Download Aspose Licence'
-            condition: eq(variables.runPdfGenerator, 'true')
-
           - task: CopyFiles@2
             inputs:
               sourceFolder: $(Agent.TempDirectory)
               contents: Aspose.Total.NET.lic
               targetFolder: 'polaris-pipeline/pdf-generator'
+              OverWrite: true
             displayName: 'Copy Aspose.Total.NET.lic to project folder before any builds occur'
-            condition: eq(variables.runPdfGenerator, 'true')
+            condition: eq(variables.runPdfGeneratorDEV, 'true')
             
           - task: DotNetCoreCLI@2
             inputs:
               command: publish
               publishWebProjects: false
               projects: "polaris-pipeline/pdf-generator/pdf-generator.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create PDF-Generator package to publish"
-            condition: eq(variables.runPdfGenerator, 'true')
+            condition: eq(variables.runPdfGeneratorDEV, 'true')
 
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.ArtifactStagingDirectory)/pdf-generator"
-              artifact: "polaris-pdf-generator-drop"
+              artifact: "polaris-pdf-generator-dev-drop"
             displayName: "Publish PDF-Generator codebase artifact"
-            condition: eq(variables.runPdfGenerator, 'true')
+            condition: eq(variables.runPdfGeneratorDEV, 'true')
             
           - task: DotNetCoreCLI@2
             inputs:
@@ -258,54 +513,54 @@ stages:
               arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
               zipAfterPublish: false
             displayName: "Create Text-Extractor package to publish"
-            condition: eq(variables.runTextExtractor, 'true')
+            condition: eq(variables.runTextExtractorDEV, 'true')
 
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.ArtifactStagingDirectory)/text-extractor"
-              artifact: "polaris-text-extractor-drop"
+              artifact: "polaris-text-extractor-dev-drop"
             displayName: "Publish Text-Extractor codebase artifact"
-            condition: eq(variables.runTextExtractor, 'true')
+            condition: eq(variables.runTextExtractorDEV, 'true')
 
           - task: DotNetCoreCLI@2
             inputs:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Auth Handover package to publish"
-            condition: eq(variables.runAuthHandover, 'true')
+            condition: eq(variables.runAuthHandoverDEV, 'true')
 
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.ArtifactStagingDirectory)/polaris-auth-handover"
-              artifact: "polaris-auth-handover-drop"
+              artifact: "polaris-auth-handover-dev-drop"
             displayName: "Publish Auth Handover codebase artifact"
-            condition: eq(variables.runAuthHandover, 'true')
+            condition: eq(variables.runAuthHandoverDEV, 'true')
             
           - task: DotNetCoreCLI@2
             inputs:
               command: publish
               publishWebProjects: false
               projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
-              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber)"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
               zipAfterPublish: false
             displayName: "Create Gateway package to publish"
-            condition: eq(variables.runGateway, 'true')
+            condition: eq(variables.runGatewayDEV, 'true')
 
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.ArtifactStagingDirectory)/polaris-gateway"
-              artifact: "polaris-gateway-drop"
+              artifact: "polaris-gateway-dev-drop"
             displayName: "Publish Gateway codebase artifact"
-            condition: eq(variables.runGateway, 'true')
+            condition: eq(variables.runGatewayDEV, 'true')
             
           # We want to rely only on the .env.production file, anything in .env is still included
           #  if not overwritten by .env.production.  For safety, just delete .env
           - task: DeleteFiles@1
             displayName: "Remove .env file"
-            condition: eq(variables.runUICodebase, 'true')
+            condition: eq(variables.runUICodebaseDEV, 'true')
             inputs:
               contents: |
                 polaris-ui/.env
@@ -313,19 +568,20 @@ stages:
           # Add build version
           - task: PowerShell@2
             displayName: "Record build version"
+            condition: eq(variables.runUICodebaseDEV, 'true')
             inputs:
               targetType: 'inline'
               workingDirectory: polaris-ui/public
               script: |
                 New-Item build-version.txt
-                Set-Content build-version.txt '$(Build.BuildNumber)'
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)'
 
           - task: Npm@1
             inputs:
               command: "install"
               workingDir: "polaris-ui"
             displayName: "npm install"
-            condition: eq(variables.runUICodebase, 'true')
+            condition: eq(variables.runUICodebaseDEV, 'true')
 
           - task: Npm@1
             inputs:
@@ -333,7 +589,7 @@ stages:
               workingDir: "polaris-ui"
               customCommand: "run prettier"
             displayName: "npm prettier"
-            condition: eq(variables.runUICodebase, 'true')
+            condition: eq(variables.runUICodebaseDEV, 'true')
 
           - task: Npm@1
             inputs:
@@ -341,19 +597,374 @@ stages:
               workingDir: "polaris-ui"
               customCommand: "run build"
             displayName: "npm build"
-            condition: eq(variables.runUICodebase, 'true')
+            condition: eq(variables.runUICodebaseDEV, 'true')
 
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "polaris-ui/build"
-              ArtifactName: "polaris-ui-drop"
+              ArtifactName: "polaris-ui-dev-drop"
               publishLocation: "Container"
             displayName: Publish UI artifact
-            condition: eq(variables.runUICodebase, 'true')
+            condition: eq(variables.runUICodebaseDEV, 'true')
             
+      - job: Build_QA_Artifacts
+        pool:
+          vmImage: ubuntu-latest
+        steps:
           - task: PublishPipelineArtifact@1
-            displayName: 'Publish pipeline scripts'
+            displayName: 'Publish pipeline terraform artifact'
+            condition: eq(variables.runPipelineTerraformQA, 'true')
             inputs:
-              targetPath: '$(Pipeline.Workspace)/s/polaris-devops-pipelines/scripts'
-              artifact: 'polaris-script-files'
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-terraform/"
+              artifact: "pipeline-terraform-files-qa"
+              publishLocation: "pipeline"
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish pipeline events terraform artifact'
+            condition: eq(variables.runPipelineEventsTerraformQA, 'true')
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-events-terraform/"
+              artifact: "pipeline-events-terraform-files-qa"
+              publishLocation: "pipeline"
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish UI terraform artifact'
+            condition: eq(variables.runUITerraformQA, 'true')
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/s/polaris-terraform/ui-terraform/'
+              artifact: 'ui-terraform-files-qa'
               publishLocation: 'pipeline'
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish UI events terraform artifact'
+            condition: eq(variables.runUIEventsTerraformQA, 'true')
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/ui-events-terraform/"
+              artifact: "ui-events-terraform-files-qa"
+              publishLocation: "pipeline"
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/coordinator/coordinator.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Coordinator package to publish"
+            condition: eq(variables.runCoordinatorQA, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/coordinator"
+              artifact: "polaris-coordinator-qa-drop"
+            displayName: "Publish Coordinator codebase artifact"
+            condition: eq(variables.runCoordinatorQA, 'true')
+
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: $(Agent.TempDirectory)
+              contents: Aspose.Total.NET.lic
+              targetFolder: 'polaris-pipeline/pdf-generator'
+              OverWrite: true
+            displayName: 'Copy Aspose.Total.NET.lic to project folder before any builds occur'
+            condition: eq(variables.runPdfGeneratorQA, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/pdf-generator/pdf-generator.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create PDF-Generator package to publish"
+            condition: eq(variables.runPdfGeneratorQA, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/pdf-generator"
+              artifact: "polaris-pdf-generator-qa-drop"
+            displayName: "Publish PDF-Generator codebase artifact"
+            condition: eq(variables.runPdfGeneratorQA, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/text-extractor/text-extractor.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Text-Extractor package to publish"
+            condition: eq(variables.runTextExtractorQA, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/text-extractor"
+              artifact: "polaris-text-extractor-qa-drop"
+            displayName: "Publish Text-Extractor codebase artifact"
+            condition: eq(variables.runTextExtractorQA, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Auth Handover package to publish"
+            condition: eq(variables.runAuthHandoverQA, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/polaris-auth-handover"
+              artifact: "polaris-auth-handover-qa-drop"
+            displayName: "Publish Auth Handover codebase artifact"
+            condition: eq(variables.runAuthHandoverQA, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Gateway package to publish"
+            condition: eq(variables.runGatewayQA, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/polaris-gateway"
+              artifact: "polaris-gateway-qa-drop"
+            displayName: "Publish Gateway codebase artifact"
+            condition: eq(variables.runGatewayQA, 'true')
+          
+          # We want to rely only on the .env.production file, anything in .env is still included
+          #  if not overwritten by .env.production.  For safety, just delete .env
+          - task: DeleteFiles@1
+            displayName: "Remove .env file"
+            condition: eq(variables.runUICodebaseQA, 'true')
+            inputs:
+              contents: |
+                polaris-ui/.env
+          
+          # Add build version
+          - task: PowerShell@2
+            displayName: "Record build version"
+            condition: eq(variables.runUICodebaseQA, 'true')
+            inputs:
+              targetType: 'inline'
+              workingDirectory: polaris-ui/public
+              script: |
+                New-Item build-version.txt
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)' 
+
+          - task: Npm@1
+            inputs:
+              command: "install"
+              workingDir: "polaris-ui"
+            displayName: "npm install"
+            condition: eq(variables.runUICodebaseQA, 'true')
+
+          - task: Npm@1
+            inputs:
+              command: "custom"
+              workingDir: "polaris-ui"
+              customCommand: "run prettier"
+            displayName: "npm prettier"
+            condition: eq(variables.runUICodebaseQA, 'true')
+
+          - task: Npm@1
+            inputs:
+              command: "custom"
+              workingDir: "polaris-ui"
+              customCommand: "run build"
+            displayName: "npm build"
+            condition: eq(variables.runUICodebaseQA, 'true')
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: "polaris-ui/build"
+              ArtifactName: "polaris-ui-qa-drop"
+              publishLocation: "Container"
+            displayName: Publish UI artifact
+            condition: eq(variables.runUICodebaseQA, 'true')
+            
+      - job: Build_PROD_Artifacts
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish pipeline terraform artifact'
+            condition: eq(variables.runPipelineTerraformPROD, 'true')
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-terraform/"
+              artifact: "pipeline-terraform-files-prod"
+              publishLocation: "pipeline"
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish pipeline events terraform artifact'
+            condition: eq(variables.runPipelineEventsTerraformPROD, 'true')
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/pipeline-events-terraform/"
+              artifact: "pipeline-events-terraform-files-prod"
+              publishLocation: "pipeline"
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish UI terraform artifact'
+            condition: eq(variables.runUITerraformPROD, 'true')
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/s/polaris-terraform/ui-terraform/'
+              artifact: 'ui-terraform-files-prod'
+              publishLocation: 'pipeline'
+
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish UI events terraform artifact'
+            condition: eq(variables.runUIEventsTerraformPROD, 'true')
+            inputs:
+              targetPath: "$(Pipeline.Workspace)/s/polaris-terraform/ui-events-terraform/"
+              artifact: "ui-events-terraform-files-prod"
+              publishLocation: "pipeline"
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/coordinator/coordinator.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Coordinator package to publish"
+            condition: eq(variables.runCoordinatorPROD, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/coordinator"
+              artifact: "polaris-coordinator-prod-drop"
+            displayName: "Publish Coordinator codebase artifact"
+            condition: eq(variables.runCoordinatorPROD, 'true')
+
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: $(Agent.TempDirectory)
+              contents: Aspose.Total.NET.lic
+              targetFolder: 'polaris-pipeline/pdf-generator'
+              OverWrite: true
+            displayName: 'Copy Aspose.Total.NET.lic to project folder before any builds occur'
+            condition: eq(variables.runPdfGeneratorPROD, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/pdf-generator/pdf-generator.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create PDF-Generator package to publish"
+            condition: eq(variables.runPdfGeneratorPROD, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/pdf-generator"
+              artifact: "polaris-pdf-generator-prod-drop"
+            displayName: "Publish PDF-Generator codebase artifact"
+            condition: eq(variables.runPdfGeneratorPROD, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-pipeline/text-extractor/text-extractor.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Text-Extractor package to publish"
+            condition: eq(variables.runTextExtractorPROD, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/text-extractor"
+              artifact: "polaris-text-extractor-prod-drop"
+            displayName: "Publish Text-Extractor codebase artifact"
+            condition: eq(variables.runTextExtractorPROD, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Auth Handover package to publish"
+            condition: eq(variables.runAuthHandoverPROD, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/polaris-auth-handover"
+              artifact: "polaris-auth-handover-prod-drop"
+            displayName: "Publish Auth Handover codebase artifact"
+            condition: eq(variables.runAuthHandoverPROD, 'true')
+
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: "polaris-gateway/polaris-gateway/polaris-gateway.csproj"
+              arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(Build.BuildNumber) /p:SourceRevisionId=$(Build.SourceVersion)"
+              zipAfterPublish: false
+            displayName: "Create Gateway package to publish"
+            condition: eq(variables.runGatewayPROD, 'true')
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.ArtifactStagingDirectory)/polaris-gateway"
+              artifact: "polaris-gateway-prod-drop"
+            displayName: "Publish Gateway codebase artifact"
+            condition: eq(variables.runGatewayPROD, 'true')
+          
+          # We want to rely only on the .env.production file, anything in .env is still included
+          #  if not overwritten by .env.production.  For safety, just delete .env
+          - task: DeleteFiles@1
+            displayName: "Remove .env file"
+            condition: eq(variables.runUICodebasePROD, 'true')
+            inputs:
+              contents: |
+                polaris-ui/.env
+          
+          # Add build version
+          - task: PowerShell@2
+            displayName: "Record build version"
+            condition: eq(variables.runUICodebasePROD, 'true')
+            inputs:
+              targetType: 'inline'
+              workingDirectory: polaris-ui/public
+              script: |
+                New-Item build-version.txt
+                Set-Content -NoNewline build-version.txt '$(Build.BuildNumber) `n$(Build.SourceVersion)' 
+
+          - task: Npm@1
+            inputs:
+              command: "install"
+              workingDir: "polaris-ui"
+            displayName: "npm install"
+            condition: eq(variables.runUICodebasePROD, 'true')
+
+          - task: Npm@1
+            inputs:
+              command: "custom"
+              workingDir: "polaris-ui"
+              customCommand: "run prettier"
+            displayName: "npm prettier"
+            condition: eq(variables.runUICodebasePROD, 'true')
+
+          - task: Npm@1
+            inputs:
+              command: "custom"
+              workingDir: "polaris-ui"
+              customCommand: "run build"
+            displayName: "npm build"
+            condition: eq(variables.runUICodebasePROD, 'true')
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: "polaris-ui/build"
+              ArtifactName: "polaris-ui-prod-drop"
+              publishLocation: "Container"
+            displayName: Publish UI artifact
+            condition: eq(variables.runUICodebasePROD, 'true')

--- a/polaris-devops-pipelines/polaris-pr-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-pr-pipeline.yml
@@ -660,18 +660,18 @@ stages:
             displayName: Publish Coordinator Test Results
             condition: eq(variables.runCoordinator, 'true')
 
-          - task: DotNetCoreCLI@2
-            inputs:
-              command: "test"
-              projects: "polaris-pipeline/pdf-generator.tests/pdf-generator.tests.csproj"
-              arguments: "--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
-            displayName: "Run Pdf-Generator tests"
-            condition: eq(variables.runPdfGenerator, 'true')
+          #- task: DotNetCoreCLI@2
+          #  inputs:
+          #    command: "test"
+          #    projects: "polaris-pipeline/pdf-generator.tests/pdf-generator.tests.csproj"
+          #    arguments: "--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
+          #  displayName: "Run Pdf-Generator tests"
+          #  condition: eq(variables.runPdfGenerator, 'true')
             
-          - publish: $(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-generator.tests/coverage.cobertura.xml
-            artifact: PdfGeneratorTestResults
-            displayName: Publish Pdf-Generator Test Results
-            condition: eq(variables.runPdfGenerator, 'true')
+          #- publish: $(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-generator.tests/coverage.cobertura.xml
+          #  artifact: PdfGeneratorTestResults
+          #  displayName: Publish Pdf-Generator Test Results
+          #  condition: eq(variables.runPdfGenerator, 'true')
 
           - task: DotNetCoreCLI@2
             inputs:

--- a/polaris-devops-pipelines/polaris-pr-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-pr-pipeline.yml
@@ -660,18 +660,18 @@ stages:
             displayName: Publish Coordinator Test Results
             condition: eq(variables.runCoordinator, 'true')
 
-          #- task: DotNetCoreCLI@2
-          #  inputs:
-          #    command: "test"
-          #    projects: "polaris-pipeline/pdf-generator.tests/pdf-generator.tests.csproj"
-          #    arguments: "--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
-          #  displayName: "Run Pdf-Generator tests"
-          #  condition: eq(variables.runPdfGenerator, 'true')
+          - task: DotNetCoreCLI@2
+            inputs:
+              command: "test"
+              projects: "polaris-pipeline/pdf-generator.tests/pdf-generator.tests.csproj"
+              arguments: "--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
+            displayName: "Run Pdf-Generator tests"
+            condition: eq(variables.runPdfGenerator, 'true')
             
-          #- publish: $(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-generator.tests/coverage.cobertura.xml
-          #  artifact: PdfGeneratorTestResults
-          #  displayName: Publish Pdf-Generator Test Results
-          #  condition: eq(variables.runPdfGenerator, 'true')
+          - publish: $(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-generator.tests/coverage.cobertura.xml
+            artifact: PdfGeneratorTestResults
+            displayName: Publish Pdf-Generator Test Results
+            condition: eq(variables.runPdfGenerator, 'true')
 
           - task: DotNetCoreCLI@2
             inputs:

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -1455,8 +1455,8 @@ stages:
     displayName: PROD Deployment
     dependsOn:
       - Determine_Changes
-      - Update_QA_Tag
-      - Run_e2e_Tests_QA
+      - Update_DEV_Tag
+      - Run_e2e_Tests_DEV
     condition: succeeded()
     variables:
       runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_PROD']]

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -35,7 +35,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                $files = $(git diff --name-only --relative --diff-filter AMR HEAD^ HEAD)
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
                 $temp=$files -split ' '
                 $count=$temp.Length
                 echo "Total changed $count files"
@@ -47,102 +47,324 @@ stages:
                   if ($name -like 'polaris-terraform/pipeline-terraform/*')
                   {
                     echo "run pipeline terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
                   {
                     echo "run pipeline events terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-terraform/ui-terraform/*')
                   {
                     echo "run ui terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"                    
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"                    
                   }
                   if ($name -like 'polaris-terraform/ui-events-terraform/*')
                   {
                     echo "run ui events terraform..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/*')
                   {
                     echo "run pipeline codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/coordinator/*')
                   {
                     echo "run coordinator..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/pdf-generator/*')
                   {
                     echo "run pdf generator..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/text-extractor/*')
                   {
                     echo "run text extractor..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/*')
                   {
                     echo "run gateway codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-gateway/*')
                   {
                     echo "run gateway..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-auth-handover/*')
                   {
                     echo "run auth handover..."
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-ui/*')
                   {
                     echo "run ui codebase..."
-                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/DdeiClient/*')
                   {
                     echo "changes to DdeiClient detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-pipeline/Common/*')
                   {
                     echo "changes to the Pipeline's Common library detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
                   }
                   if ($name -like 'polaris-gateway/polaris-gateway.common/*')
                   {
                     echo "changes to the Gateway's Common library detected run dependent code-bases..."
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER;isOutput=true]true"
-                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_DEV;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_DEV;isOutput=true]true"
+                  }
+                }
+                
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
+                $temp=$files -split ' '
+                $count=$temp.Length
+                echo "Total changed $count files"
+
+                For ($i=0; $i -lt $temp.Length; $i++)
+                {
+                  $name=$temp[$i]
+                  echo "this is $name file"
+                  if ($name -like 'polaris-terraform/pipeline-terraform/*')
+                  {
+                    echo "run pipeline terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
+                  {
+                    echo "run pipeline events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/ui-terraform/*')
+                  {
+                    echo "run ui terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"                    
+                  }
+                  if ($name -like 'polaris-terraform/ui-events-terraform/*')
+                  {
+                    echo "run ui events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/*')
+                  {
+                    echo "run pipeline codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/coordinator/*')
+                  {
+                    echo "run coordinator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/pdf-generator/*')
+                  {
+                    echo "run pdf generator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/text-extractor/*')
+                  {
+                    echo "run text extractor..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/*')
+                  {
+                    echo "run gateway codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway/*')
+                  {
+                    echo "run gateway..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-auth-handover/*')
+                  {
+                    echo "run auth handover..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-ui/*')
+                  {
+                    echo "run ui codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/DdeiClient/*')
+                  {
+                    echo "changes to DdeiClient detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/Common/*')
+                  {
+                    echo "changes to the Pipeline's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway.common/*')
+                  {
+                    echo "changes to the Gateway's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_QA;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_QA;isOutput=true]true"
+                  }
+                }
+                
+                $files = $(git diff --name-only --relative --diff-filter AMRD dev HEAD)
+                $temp=$files -split ' '
+                $count=$temp.Length
+                echo "Total changed $count files"
+
+                For ($i=0; $i -lt $temp.Length; $i++)
+                {
+                  $name=$temp[$i]
+                  echo "this is $name file"
+                  if ($name -like 'polaris-terraform/pipeline-terraform/*')
+                  {
+                    echo "run pipeline terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/pipeline-events-terraform/*')
+                  {
+                    echo "run pipeline events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-terraform/ui-terraform/*')
+                  {
+                    echo "run ui terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"                    
+                  }
+                  if ($name -like 'polaris-terraform/ui-events-terraform/*')
+                  {
+                    echo "run ui events terraform..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_EVENTS_TERRAFORM_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/*')
+                  {
+                    echo "run pipeline codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/coordinator/*')
+                  {
+                    echo "run coordinator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/pdf-generator/*')
+                  {
+                    echo "run pdf generator..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/text-extractor/*')
+                  {
+                    echo "run text extractor..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/*')
+                  {
+                    echo "run gateway codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway/*')
+                  {
+                    echo "run gateway..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-auth-handover/*')
+                  {
+                    echo "run auth handover..."
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-ui/*')
+                  {
+                    echo "run ui codebase..."
+                    Write-Host "##vso[task.setvariable variable=RUN_UI_CODEBASE_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/DdeiClient/*')
+                  {
+                    echo "changes to DdeiClient detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-pipeline/Common/*')
+                  {
+                    echo "changes to the Pipeline's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_PDF_GENERATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_TEXT_EXTRACTOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
+                  }
+                  if ($name -like 'polaris-gateway/polaris-gateway.common/*')
+                  {
+                    echo "changes to the Gateway's Common library detected run dependent code-bases..."
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_CODEBASE_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_PIPELINE_COORDINATOR_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_AUTH_HANDOVER_PROD;isOutput=true]true"
+                    Write-Host "##vso[task.setvariable variable=RUN_GATEWAY_GATEWAY_PROD;isOutput=true]true"
                   }
                 }
             name: Change_Results
@@ -153,21 +375,20 @@ stages:
     condition: succeeded()
     dependsOn: Determine_Changes
     variables:
-      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM']]
-      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
-      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM']]
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
+      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_DEV']]
+      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_DEV']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_DEV']]
+      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_DEV']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_DEV']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_DEV']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_DEV']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_DEV']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_DEV']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_DEV']]
     pool:
       name: $(dev-build-agent)
     jobs:
-      - deployment: CI_Deployment
-        condition: or(eq(variables.runPipelineTerraform, 'true'),eq(variables.runPipelineEventsTerraform, 'true'),eq(variables.runUITerraform, 'true'),eq(variables.runUIEventsTerraform, 'true'),eq(variables.runCoordinator, 'true'),eq(variables.runPdfGenerator, 'true'),eq(variables.runTextExtractor, 'true'),eq(variables.runGateway, 'true'),eq(variables.runAuthHandover, 'true'),eq(variables.runUICodebase, 'true'))
+      - deployment: CI_Deploy_Polaris
         environment: "Dev"
         strategy:
           runOnce:
@@ -184,7 +405,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineTerraform, 'true')
                   displayName: Terraform > Download Pipeline terraform build
-                  artifact: "pipeline-terraform-files"
+                  artifact: "pipeline-terraform-files-dev"
                 
                 # Terraform Init
                 - bash: |
@@ -195,7 +416,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init Main Pipeline
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-dev
                   env:
                     TF_STATE_ACCOUNT_NAME: $(dev-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-terraform-container-name)
@@ -208,7 +429,7 @@ stages:
                     terraform plan -input=false -out=dev.tfplan -var-file="dev.tfvars"
                   displayName: Terraform > Write Pipeline Plan
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -221,7 +442,7 @@ stages:
                     terraform apply -auto-approve dev.tfplan
                   displayName: Terraform > Apply Main Pipeline
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -233,7 +454,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runCoordinator, 'true')
                   displayName: Deploy > Download Coordinator Codebase Build
-                  artifact: "polaris-coordinator-drop"
+                  artifact: "polaris-coordinator-dev-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -243,13 +464,13 @@ stages:
                     azureSubscription: $(dev-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-dev-coordinator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-dev-drop
                 
                 #download pdf-generator build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPdfGenerator, 'true')
                   displayName: Deploy > Download PDF Generator Codebase Build
-                  artifact: "polaris-pdf-generator-drop"
+                  artifact: "polaris-pdf-generator-dev-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -259,13 +480,13 @@ stages:
                     azureSubscription: $(dev-azure-subscription)
                     appType: functionApp
                     appName: "fa-polaris-pipeline-dev-pdf-generator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-dev-drop
                 
                 #download text-extractor build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runTextExtractor, 'true')
                   displayName: Deploy > Download Text Extractor Codebase Build
-                  artifact: "polaris-text-extractor-drop"
+                  artifact: "polaris-text-extractor-dev-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -275,13 +496,13 @@ stages:
                     azureSubscription: $(dev-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-dev-text-extractor"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-dev-drop
                 
                 #download pipeline events terraform build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
                   displayName: Terraform > Download Pipeline Events terraform build
-                  artifact: "pipeline-events-terraform-files"
+                  artifact: "pipeline-events-terraform-files-dev"
                 
                 # Terraform Init
                 - bash: |
@@ -292,7 +513,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init Pipeline Events
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-dev
                   env:
                     TF_STATE_ACCOUNT_NAME: $(dev-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-events-terraform-container-name)
@@ -305,7 +526,7 @@ stages:
                     terraform plan -input=false -out=dev.tfplan -var-file="dev.tfvars"
                   displayName: Terraform > Write Pipeline Events Plan
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -318,7 +539,7 @@ stages:
                     terraform apply -auto-approve dev.tfplan
                   displayName: Terraform > Apply Pipeline Events
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -330,7 +551,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUITerraform, 'true')
                   displayName: Terraform > Download UI terraform build
-                  artifact: "ui-terraform-files"
+                  artifact: "ui-terraform-files-dev"
                 
                 # Terraform Init
                 - bash: |
@@ -341,7 +562,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init UI Terraform
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-dev
                   env:
                     TF_STATE_ACCOUNT_NAME: $(dev-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-terraform-container-name)
@@ -354,7 +575,7 @@ stages:
                     terraform plan -input=false -out=dev.tfplan -var-file="dev.tfvars"
                   displayName: Terraform > Write UI Plan
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -367,19 +588,35 @@ stages:
                     terraform apply -auto-approve dev.tfplan
                   displayName: Terraform > Apply UI Terraform
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
                     TF_LOG: $(dev-log-level)
-                
+                    
+                #download UI build artifact
+                - download: PolarisBuild
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-dev-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: 'Deploy SPA App Service to DEV'
+                  inputs:
+                    azureSubscription: $(dev-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-dev"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-dev-drop
+                                
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runGateway, 'true')
                   displayName: Deploy > Download Gateway Codebase Build
-                  artifact: "polaris-gateway-drop"
+                  artifact: "polaris-gateway-dev-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -389,13 +626,13 @@ stages:
                     azureSubscription: $(dev-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-gateway"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-dev-drop
                 
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runAuthHandover, 'true')
                   displayName: Deploy > Download Auth Handover Codebase Build
-                  artifact: "polaris-auth-handover-drop"
+                  artifact: "polaris-auth-handover-dev-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -405,25 +642,9 @@ stages:
                     azureSubscription: $(dev-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-dev-drop
                 
-                #download UI build artifact
-                - download: PolarisBuild
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: 'Deploy SPA App Service to DEV'
-                  inputs:
-                    azureSubscription: $(dev-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-dev"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-drop
-                
-                # Restart app service    
+                # Restart app service - moved away from deployment to buy some time    
                 - task: AzureAppServiceManage@0
                   condition: eq(variables.runUICodebase, 'true')
                   displayName: 'Restart SPA Azure App Service'
@@ -436,7 +657,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUIEventsTerraform, 'true')
                   displayName: Terraform > Download UI Events terraform build
-                  artifact: "ui-events-terraform-files"
+                  artifact: "ui-events-terraform-files-dev"
                 
                 # Terraform Init
                 - bash: |
@@ -447,7 +668,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init UI Events
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-dev
                   env:
                     TF_STATE_ACCOUNT_NAME: $(dev-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-events-terraform-container-name)
@@ -460,7 +681,7 @@ stages:
                     terraform plan -input=false -out=dev.tfplan -var-file="dev.tfvars"
                   displayName: Terraform > Write UI Events Plan
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -473,7 +694,7 @@ stages:
                     terraform apply -auto-approve dev.tfplan
                   displayName: Terraform > Apply UI Events
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-dev
                   env:
                     ARM_CLIENT_ID: $(innovation-development-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
@@ -488,13 +709,13 @@ stages:
       - Apply_DEV
     condition: succeeded()
     variables:
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_DEV']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_DEV']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_DEV']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_DEV']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_DEV']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_DEV']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_DEV']]
     pool:
       name: $(dev-build-agent)
     jobs:
@@ -616,7 +837,44 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
-        
+
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Check_DEV
+    condition: succeeded()
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log dev...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-dev.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV"
+            displayName: "Publish Commit report for DEV"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/dev
+                git tag -f dev
+                git tag -f $(resources.pipeline.PolarisBuild.runName)
+                git push origin --tags
+            displayName: Updating the dev tag        
                     
   - stage: Run_e2e_Tests
     displayName: Run e2e tests > DEV
@@ -624,18 +882,19 @@ stages:
       - Determine_Changes
       - Apply_DEV
       - Check_DEV
+      - Update_DEV_Tag
     condition: succeeded()
     variables:
-      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM']]
-      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
-      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM']]
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
+      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_DEV']]
+      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_DEV']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_DEV']]
+      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_DEV']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_DEV']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_DEV']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_DEV']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_DEV']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_DEV']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_DEV']]
     jobs:
       - job: Run_e2e_Tests
         pool:
@@ -654,23 +913,24 @@ stages:
     displayName: Deployment > QA
     dependsOn:
       - Determine_Changes
+      - Update_DEV_Tag
       - Run_e2e_Tests
     condition: succeeded()
     variables:
-      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM']]
-      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
-      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM']]
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
+      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_QA']]
+      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_QA']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_QA']]
+      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_QA']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_QA']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_QA']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_QA']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_QA']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_QA']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_QA']]
     pool:
       name: $(qa-build-agent)
     jobs:
-      - deployment: CI_Deployment
+      - deployment: CI_Deploy_Polaris
         environment: "QA"
         strategy:
           runOnce:
@@ -687,7 +947,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineTerraform, 'true')
                   displayName: Terraform > Download Pipeline terraform build
-                  artifact: "pipeline-terraform-files"
+                  artifact: "pipeline-terraform-files-qa"
                 
                 # Terraform Init
                 - bash: |
@@ -698,7 +958,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-qa
                   env:
                     TF_STATE_ACCOUNT_NAME: $(qa-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-terraform-container-name)
@@ -711,7 +971,7 @@ stages:
                     terraform plan -input=false -out=qa.tfplan -var-file="qa.tfvars"
                   displayName: 'Terraform > Write Pipeline Plan'
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -724,7 +984,7 @@ stages:
                     terraform apply -auto-approve qa.tfplan
                   displayName: Terraform > Apply to QA
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -736,7 +996,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runCoordinator, 'true')
                   displayName: Deploy > Download Coordinator Codebase Build
-                  artifact: "polaris-coordinator-drop"
+                  artifact: "polaris-coordinator-qa-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -746,13 +1006,13 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-qa-coordinator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-qa-drop
                 
                 #download pdf-generator build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPdfGenerator, 'true')
                   displayName: Deploy > Download PDF Generator Codebase Build
-                  artifact: "polaris-pdf-generator-drop"
+                  artifact: "polaris-pdf-generator-qa-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -762,13 +1022,13 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     appType: functionApp
                     appName: "fa-polaris-pipeline-qa-pdf-generator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-qa-drop
                 
                 #download text-extractor build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runTextExtractor, 'true')
                   displayName: Deploy > Download Text Extractor Codebase Build
-                  artifact: "polaris-text-extractor-drop"
+                  artifact: "polaris-text-extractor-qa-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -778,13 +1038,13 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-qa-text-extractor"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-qa-drop
                 
                 #download pipeline events terraform build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
                   displayName: Terraform > Download Pipeline Events terraform build
-                  artifact: "pipeline-events-terraform-files"
+                  artifact: "pipeline-events-terraform-files-qa"
                 
                 # Terraform Init
                 - bash: |
@@ -795,7 +1055,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-qa
                   env:
                     TF_STATE_ACCOUNT_NAME: $(qa-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-events-terraform-container-name)
@@ -808,7 +1068,7 @@ stages:
                     terraform plan -input=false -out=qa.tfplan -var-file="qa.tfvars"
                   displayName: 'Terraform > Write Pipeline Events Plan'
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -821,7 +1081,7 @@ stages:
                     terraform apply -auto-approve qa.tfplan
                   displayName: Terraform > Apply to QA
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -833,7 +1093,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUITerraform, 'true')
                   displayName: Terraform > Download UI terraform build
-                  artifact: "ui-terraform-files"
+                  artifact: "ui-terraform-files-qa"
                 
                 # Terraform Init
                 - bash: |
@@ -844,7 +1104,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-qa
                   env:
                     TF_STATE_ACCOUNT_NAME: $(qa-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-terraform-container-name)
@@ -857,7 +1117,7 @@ stages:
                     terraform plan -input=false -out=qa.tfplan -var-file="qa.tfvars"
                   displayName: 'Terraform > Write UI Plan'
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -870,19 +1130,35 @@ stages:
                     terraform apply -auto-approve qa.tfplan
                   displayName: Terraform > Apply to QA
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
                     TF_LOG: $(qa-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisBuild
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-qa-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: 'Deploy UI App Service to QA'
+                  inputs:
+                    azureSubscription: $(qa-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris-qa"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-qa-drop
                 
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runGateway, 'true')
                   displayName: Deploy > Download Gateway Codebase Build
-                  artifact: "polaris-gateway-drop"
+                  artifact: "polaris-gateway-qa-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -892,13 +1168,13 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-gateway"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-qa-drop
                 
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runAuthHandover, 'true')
                   displayName: Deploy > Download Auth Handover Codebase Build
-                  artifact: "polaris-auth-handover-drop"
+                  artifact: "polaris-auth-handover-qa-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -908,23 +1184,7 @@ stages:
                     azureSubscription: $(qa-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisBuild
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: 'Deploy UI App Service to QA'
-                  inputs:
-                    azureSubscription: $(qa-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris-qa"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-qa-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -939,7 +1199,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUIEventsTerraform, 'true')
                   displayName: Terraform > Download UI Events terraform build
-                  artifact: "ui-events-terraform-files"
+                  artifact: "ui-events-terraform-files-qa"
                 
                 # Terraform Init
                 - bash: |
@@ -950,7 +1210,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-qa
                   env:
                     TF_STATE_ACCOUNT_NAME: $(qa-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-events-terraform-container-name)
@@ -963,7 +1223,7 @@ stages:
                     terraform plan -input=false -out=qa.tfplan -var-file="qa.tfvars"
                   displayName: 'Terraform > Write UI Events Plan'
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -976,7 +1236,7 @@ stages:
                     terraform apply -auto-approve qa.tfplan
                   displayName: Terraform > Apply to QA
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-qa
                   env:
                     ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
@@ -991,13 +1251,13 @@ stages:
       - Apply_QA
     condition: succeeded()
     variables:
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_QA']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_QA']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_QA']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_QA']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_QA']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_QA']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_QA']]
     pool:
       name: $(qa-build-agent)
     jobs:
@@ -1119,28 +1379,67 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Check_QA
+    condition: succeeded()
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log qa...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-qa.csv
+            displayName: Generate commit report for QA
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
+              artifact: "Commit Report - QA"
+            displayName: "Publish Commit report for QA"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/qa
+                git tag -f qa
+                git tag -f $(resources.pipeline.PolarisBuild.runName)
+                git push origin --tags 
+            displayName: Updating the qa tag
 
   - stage: Apply_PROD
     displayName: PROD Deployment
     dependsOn:
       - Determine_Changes
       - Check_QA
+      - Update_QA_Tag
     condition: succeeded()
     variables:
-      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM']]
-      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
-      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM']]
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
+      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_PROD']]
+      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_PROD']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_PROD']]
+      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_PROD']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_PROD']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_PROD']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_PROD']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_PROD']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_PROD']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_PROD']]
     pool:
       name: $(prod-build-agent)
     jobs:
-      - deployment: CI_Deployment
+      - deployment: CI_Deploy_Polaris
         environment: "Prod"
         strategy:
           runOnce:
@@ -1157,7 +1456,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineTerraform, 'true')
                   displayName: Terraform > Download Pipeline terraform build
-                  artifact: "pipeline-terraform-files"
+                  artifact: "pipeline-terraform-files-prod"
                 
                 # Terraform Init
                 - bash: |
@@ -1168,7 +1467,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-prod
                   env:
                     TF_STATE_ACCOUNT_NAME: $(prod-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-terraform-container-name)
@@ -1181,7 +1480,7 @@ stages:
                     terraform plan -input=false -out=prod.tfplan -var-file="prod.tfvars"
                   displayName: 'Terraform > Write Pipeline Plan'
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1194,7 +1493,7 @@ stages:
                     terraform apply -auto-approve prod.tfplan
                   displayName: Terraform > Apply to PROD
                   condition: eq(variables.runPipelineTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1206,7 +1505,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runCoordinator, 'true')
                   displayName: Deploy > Download Coordinator Codebase Build
-                  artifact: "polaris-coordinator-drop"
+                  artifact: "polaris-coordinator-prod-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -1216,13 +1515,13 @@ stages:
                     azureSubscription: $(prod-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-coordinator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-coordinator-prod-drop
                 
                 #download pdf-generator build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPdfGenerator, 'true')
                   displayName: Deploy > Download PDF Generator Codebase Build
-                  artifact: "polaris-pdf-generator-drop"
+                  artifact: "polaris-pdf-generator-prod-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -1232,13 +1531,13 @@ stages:
                     azureSubscription: $(prod-azure-subscription)
                     appType: functionApp
                     appName: "fa-polaris-pipeline-pdf-generator"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-pdf-generator-prod-drop
                 
                 #download text-extractor build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runTextExtractor, 'true')
                   displayName: Deploy > Download Text Extractor Codebase Build
-                  artifact: "polaris-text-extractor-drop"
+                  artifact: "polaris-text-extractor-prod-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -1248,13 +1547,13 @@ stages:
                     azureSubscription: $(prod-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-pipeline-text-extractor"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-text-extractor-prod-drop
                 
                 #download pipeline events terraform build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
                   displayName: Terraform > Download Pipeline Events terraform build
-                  artifact: "pipeline-events-terraform-files"
+                  artifact: "pipeline-events-terraform-files-prod"
                 
                 # Terraform Init
                 - bash: |
@@ -1265,7 +1564,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-prod
                   env:
                     TF_STATE_ACCOUNT_NAME: $(prod-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(pipeline-events-terraform-container-name)
@@ -1278,7 +1577,7 @@ stages:
                     terraform plan -input=false -out=prod.tfplan -var-file="prod.tfvars"
                   displayName: 'Terraform > Write Pipeline Events Plan'
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1291,7 +1590,7 @@ stages:
                     terraform apply -auto-approve prod.tfplan
                   displayName: Terraform > Apply to PROD
                   condition: eq(variables.runPipelineEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/pipeline-events-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1303,7 +1602,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUITerraform, 'true')
                   displayName: Terraform > Download UI terraform build
-                  artifact: "ui-terraform-files"
+                  artifact: "ui-terraform-files-prod"
                 
                 # Terraform Init
                 - bash: |
@@ -1314,7 +1613,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-prod
                   env:
                     TF_STATE_ACCOUNT_NAME: $(prod-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-terraform-container-name)
@@ -1327,7 +1626,7 @@ stages:
                     terraform plan -input=false -out=prod.tfplan -var-file="prod.tfvars"
                   displayName: 'Terraform > Write UI Plan'
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1340,19 +1639,35 @@ stages:
                     terraform apply -auto-approve prod.tfplan
                   displayName: Terraform > Apply to PROD
                   condition: eq(variables.runUITerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
                     TF_LOG: $(prod-log-level)
+                    
+                #download UI build artifact
+                - download: PolarisBuild
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: Deploy > Download SPA Codebase Build
+                  artifact: "polaris-ui-prod-drop"
+
+                # Deploy Related Codebase to Env
+                - task: AzureRmWebAppDeployment@4
+                  condition: eq(variables.runUICodebase, 'true')
+                  displayName: 'Deploy UI App Service to PROD'
+                  inputs:
+                    azureSubscription: $(prod-azure-subscription)
+                    appType: webAppLinux
+                    WebAppName: "as-web-polaris"
+                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-prod-drop
                 
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runGateway, 'true')
                   displayName: Deploy > Download Gateway Codebase Build
-                  artifact: "polaris-gateway-drop"
+                  artifact: "polaris-gateway-prod-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -1362,13 +1677,13 @@ stages:
                     azureSubscription: $(prod-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-gateway"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-gateway-prod-drop
                 
                 #download gateway build artifact
                 - download: PolarisBuild
                   condition: eq(variables.runAuthHandover, 'true')
                   displayName: Deploy > Download Auth Handover Codebase Build
-                  artifact: "polaris-auth-handover-drop"
+                  artifact: "polaris-auth-handover-prod-drop"
                 
                 # Deploy Related Codebase to Env
                 - task: AzureFunctionApp@1
@@ -1378,23 +1693,7 @@ stages:
                     azureSubscription: $(prod-azure-subscription)
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
-                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
-                
-                #download UI build artifact
-                - download: PolarisBuild
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: Deploy > Download SPA Codebase Build
-                  artifact: "polaris-ui-drop"
-                
-                # Deploy Related Codebase to Env
-                - task: AzureRmWebAppDeployment@4
-                  condition: eq(variables.runUICodebase, 'true')
-                  displayName: 'Deploy UI App Service to PROD'
-                  inputs:
-                    azureSubscription: $(prod-azure-subscription)
-                    appType: webAppLinux
-                    WebAppName: "as-web-polaris"
-                    packageForLinux: $(Pipeline.Workspace)/PolarisBuild/polaris-ui-drop
+                    package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-prod-drop
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -1409,7 +1708,7 @@ stages:
                 - download: PolarisBuild
                   condition: eq(variables.runUIEventsTerraform, 'true')
                   displayName: Terraform > Download UI Events terraform build
-                  artifact: "ui-events-terraform-files"
+                  artifact: "ui-events-terraform-files-prod"
                 
                 # Terraform Init
                 - bash: |
@@ -1420,7 +1719,7 @@ stages:
                       -backend-config="access_key=$TF_STATE_ACCESS_KEY"
                   displayName: Terraform > Init
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-prod
                   env:
                     TF_STATE_ACCOUNT_NAME: $(prod-terraform-storage-account)
                     TF_STATE_CONTAINER_NAME: $(ui-events-terraform-container-name)
@@ -1433,7 +1732,7 @@ stages:
                     terraform plan -input=false -out=prod.tfplan -var-file="prod.tfvars"
                   displayName: 'Terraform > Write UI Events Plan'
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1446,7 +1745,7 @@ stages:
                     terraform apply -auto-approve prod.tfplan
                   displayName: Terraform > Apply to PROD
                   condition: eq(variables.runUIEventsTerraform, 'true')
-                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-events-terraform-files-prod
                   env:
                     ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
@@ -1461,13 +1760,13 @@ stages:
       - Apply_PROD
     condition: succeeded()
     variables:
-      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR']]
-      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR']]
-      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR']]
-      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY']]
-      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER']]
-      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE']]
-      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_PROD']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_PROD']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_PROD']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_PROD']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_PROD']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_PROD']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_PROD']]
     pool:
       name: $(prod-build-agent)
     jobs:
@@ -1589,3 +1888,41 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Check_PROD
+    condition: succeeded()
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for PROD
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git config user.name "$BUILD_REQUESTEDFOR"
+                git config user.email "$BUILD_REQUESTEDFOREMAIL"
+                
+                git push origin :refs/tags/prod
+                git tag -f prod
+                git tag -f $(resources.pipeline.PolarisBuild.runName)
+                git push origin --tags 
+            displayName: Updating the prod tag

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -876,7 +876,7 @@ stages:
                 git push origin --tags
             displayName: Updating the dev tag        
                     
-  - stage: Run_e2e_Tests
+  - stage: Run_e2e_Tests_DEV
     displayName: Run e2e tests > DEV
     dependsOn: 
       - Determine_Changes
@@ -896,12 +896,12 @@ stages:
       runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_DEV']]
       runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_DEV']]
     jobs:
-      - job: Run_e2e_Tests
+      - job: Run_e2e_Tests_DEV
         pool:
           vmImage: windows-latest
         steps:
           - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
-            displayName: 'Run the e2e tests'
+            displayName: 'Run the e2e tests: DEV'
             condition: or(eq(variables.runPipelineTerraform, 'true'),eq(variables.runPipelineEventsTerraform, 'true'),eq(variables.runUITerraform, 'true'),eq(variables.runUIEventsTerraform, 'true'),eq(variables.runCoordinator, 'true'),eq(variables.runPdfGenerator, 'true'),eq(variables.runTextExtractor, 'true'),eq(variables.runGateway, 'true'),eq(variables.runAuthHandover, 'true'),eq(variables.runUICodebase, 'true'))
             inputs:
               buildDefinition: 129
@@ -914,7 +914,7 @@ stages:
     dependsOn:
       - Determine_Changes
       - Update_DEV_Tag
-      - Run_e2e_Tests
+      - Run_e2e_Tests_DEV
     condition: succeeded()
     variables:
       runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_QA']]
@@ -1417,13 +1417,46 @@ stages:
                 git tag -f $(resources.pipeline.PolarisBuild.runName)
                 git push origin --tags 
             displayName: Updating the qa tag
+            
+  - stage: Run_e2e_Tests_QA
+    displayName: Run e2e tests > QA
+    dependsOn:
+      - Determine_Changes
+      - Apply_QA
+      - Check_QA
+      - Update_QA_Tag
+    condition: succeeded()
+    variables:
+      runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_QA']]
+      runPipelineEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_EVENTS_TERRAFORM_QA']]
+      runUITerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_TERRAFORM_QA']]
+      runUIEventsTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_EVENTS_TERRAFORM_QA']]
+      runCoordinator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_COORDINATOR_QA']]
+      runPdfGenerator: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_PDF_GENERATOR_QA']]
+      runTextExtractor: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TEXT_EXTRACTOR_QA']]
+      runGateway: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_GATEWAY_QA']]
+      runAuthHandover: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_GATEWAY_AUTH_HANDOVER_QA']]
+      runUICodebase: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_UI_CODEBASE_QA']]
+    jobs:
+      - job: Run_e2e_Tests_QA
+        pool:
+          vmImage: windows-latest
+        steps:
+          - task: benjhuser.tfs-extensions-build-tasks.trigger-build-task.TriggerBuild@4
+            displayName: 'Run the e2e tests: QA'
+            condition: or(eq(variables.runPipelineTerraform, 'true'),eq(variables.runPipelineEventsTerraform, 'true'),eq(variables.runUITerraform, 'true'),eq(variables.runUIEventsTerraform, 'true'),eq(variables.runCoordinator, 'true'),eq(variables.runPdfGenerator, 'true'),eq(variables.runTextExtractor, 'true'),eq(variables.runGateway, 'true'),eq(variables.runAuthHandover, 'true'),eq(variables.runUICodebase, 'true'))
+            inputs:
+              buildDefinition: 210
+              waitForQueuedBuildsToFinish: true
+              cancelBuildsIfAnyFails: true
+              password: $(devops-pat-token)
 
   - stage: Apply_PROD
     displayName: PROD Deployment
     dependsOn:
       - Determine_Changes
-      - Check_QA
       - Update_QA_Tag
+      - Run_e2e_Tests_QA
     condition: succeeded()
     variables:
       runPipelineTerraform: $[stageDependencies.Determine_Changes.Generate_Diff.outputs['Change_Results.RUN_PIPELINE_TERRAFORM_PROD']]

--- a/polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj
+++ b/polaris-gateway/polaris-auth-handover/polaris-auth-handover.csproj
@@ -4,9 +4,6 @@
         <AzureFunctionsVersion>V4</AzureFunctionsVersion>
         <RootNamespace>PolarisAuthHandover</RootNamespace>
     </PropertyGroup>
-    <PropertyGroup>
-        <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-    </PropertyGroup>
     <ItemGroup>
 		<PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.2" />
 	</ItemGroup>

--- a/polaris-gateway/polaris-gateway/polaris-gateway.csproj
+++ b/polaris-gateway/polaris-gateway/polaris-gateway.csproj
@@ -8,9 +8,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <PropertyGroup>
-    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-  </PropertyGroup>
-  <PropertyGroup>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>

--- a/polaris-pipeline/Common/Extensions/AssemblyExtensions.cs
+++ b/polaris-pipeline/Common/Extensions/AssemblyExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using Common.Health.Status;
@@ -15,11 +16,14 @@ public static class AssemblyExtensions
             return new JsonResult(new {status = "Assembly version could not be retrieved"}) {StatusCode = (int) HttpStatusCode.BadRequest};
         
         var assemblyName = currentAssembly.GetName();
+        var infoVerAttr =(AssemblyInformationalVersionAttribute) currentAssembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute))
+            .FirstOrDefault();
         
         var response = new AssemblyStatus
         {
             Name = assemblyName.Name,
-            Version = assemblyName.Version?.ToString(),
+            BuildVersion = assemblyName.Version?.ToString(),
+            SourceVersion = GetShortHash(infoVerAttr), 
             LastBuilt = GetBuildDate(currentAssembly)
         };
         return new JsonResult(response) {StatusCode = (int) HttpStatusCode.OK};
@@ -39,5 +43,16 @@ public static class AssemblyExtensions
         value = value[(index + buildVersionMetadataPrefix.Length)..];
         return DateTime.TryParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.None, out var result) 
             ? result : default;
+    }
+    
+    private static string GetShortHash(AssemblyInformationalVersionAttribute infoVerAttr)
+    {
+        var version = "1.0.0+LOCALBUILD"; // Dummy version for local dev
+        if (infoVerAttr == null || infoVerAttr.InformationalVersion.Length <= 6) return version;
+        
+        // Hash is embedded in the version after a '+' symbol, e.g. 1.0.0+a34a913742f8845d3da5309b7b17242222d41a21
+        version = infoVerAttr.InformationalVersion;
+        var longHash = version[(version.IndexOf('+') + 1)..];
+        return longHash.Substring(longHash.Length - 6, 6);
     }
 }

--- a/polaris-pipeline/Common/Extensions/AssemblyExtensions.cs
+++ b/polaris-pipeline/Common/Extensions/AssemblyExtensions.cs
@@ -44,6 +44,6 @@ public static class AssemblyExtensions
         // Hash is embedded in the version after a '+' symbol, e.g. 1.0.0+a34a913742f8845d3da5309b7b17242222d41a21
         version = infoVerAttr.InformationalVersion;
         var longHash = version[(version.IndexOf('+') + 1)..];
-        return longHash.Substring(longHash.Length - 6, 6);
+        return longHash[..8];
     }
 }

--- a/polaris-pipeline/Common/Health/Status/AssemblyStatus.cs
+++ b/polaris-pipeline/Common/Health/Status/AssemblyStatus.cs
@@ -6,7 +6,9 @@ namespace Common.Health.Status
 	{
 		public string Name { get; set; }
 		
-		public string Version { get; set; }
+		public string BuildVersion { get; set; }
+
+		public string SourceVersion { get; set; }
 
 		public DateTime LastBuilt { get; set; }
 	}

--- a/polaris-pipeline/coordinator/coordinator.csproj
+++ b/polaris-pipeline/coordinator/coordinator.csproj
@@ -5,9 +5,6 @@
     <RootNamespace>coordinator</RootNamespace>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
-  <PropertyGroup>
-    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/polaris-pipeline/pdf-generator/pdf-generator.csproj
+++ b/polaris-pipeline/pdf-generator/pdf-generator.csproj
@@ -5,9 +5,6 @@
     <RootNamespace>pdf_generator</RootNamespace>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
-  <PropertyGroup>
-    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-  </PropertyGroup>
   <ItemGroup>
 
     <PackageReference Include="Ardalis.SmartEnum" Version="2.1.0" />

--- a/polaris-pipeline/text-extractor/text-extractor.csproj
+++ b/polaris-pipeline/text-extractor/text-extractor.csproj
@@ -5,9 +5,6 @@
     <RootNamespace>text_extractor</RootNamespace>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
-  <PropertyGroup>
-    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="3.2.1" />


### PR DESCRIPTION
Added tagged releases using env-related tags (DEV, QAand PROD). Build sets are built against the position of the env-tag against HEAD. Added status endpoint result that now includes a different source for the date, formatted into GMT and the commit-id SHA. Also generates report artifacts in the release pipelines that list all commit messages pushed to the environment for that release and reflecting the number of changes based on the aforementioned env tags. Added QA e2e tests to all release pipelines, including e2e tests to DEV and QA for the manual pipelines.