### PR TITLE
Added temp script (until Terraform Provider v4 is released) that sets archival periods

### DIFF
--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -308,9 +308,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -318,6 +318,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(dev-log-level)
                 
                 # Restart app service    
@@ -769,9 +771,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -779,6 +781,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
@@ -1230,9 +1234,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -1240,6 +1244,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(prod-log-level)
 
                 # Restart app service    

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -304,6 +304,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-development-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
+                    ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    TF_LOG: $(dev-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -750,6 +765,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
+                    ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -1196,6 +1226,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
+                    ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    TF_LOG: $(prod-log-level)
 
                 # Restart app service    
                 - task: AzureAppServiceManage@0

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -176,9 +176,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -186,6 +186,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(dev-log-level)
                 
                 # Restart app service    
@@ -505,9 +507,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -515,6 +517,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
@@ -834,9 +838,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -844,6 +848,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(prod-log-level)
                 
                 # Restart app service    

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -172,6 +172,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-development-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
+                    ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    TF_LOG: $(dev-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -486,6 +501,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
+                    ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -800,6 +830,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisManualUIOnlyTerraformBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
+                    ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    TF_LOG: $(prod-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0

--- a/polaris-devops-pipelines/manual/polaris-test-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-test-pipeline.yml
@@ -1,0 +1,33 @@
+# Quick and dirty test pipeline to explore potential scripts
+
+trigger: none
+pr: none
+
+variables:
+  - group: kv-dev-terraform
+  - group: polaris-global
+  - group: pipeline-terraform
+  - group: ui-terraform
+
+stages:
+  - stage: Run_Script
+    displayName: Test > Script
+    pool:
+      name: $(dev-build-agent)
+    jobs:
+      - job: Execute
+        steps:
+          # Set Log Analytics Archival Period - remove when supported natively by Terraform
+          - bash: |
+              az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+              az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+              az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+              az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+            displayName: Script > Set Log Analytics Archival Periods
+            env:
+              ARM_CLIENT_ID: $(innovation-development-spn-client-id)
+              ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
+              ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
+              ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+              LOG_RETENTION_TIME: $(log-retention-time)
+              TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -643,6 +643,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-dev-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-development-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
+                    ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    TF_LOG: $(dev-log-level)
                 
                 # Restart app service - moved away from deployment to buy some time    
                 - task: AzureAppServiceManage@0
@@ -1184,6 +1199,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-qa-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-qa-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
+                    ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0
@@ -1725,6 +1755,21 @@ stages:
                     appType: functionAppLinux
                     appName: "fa-polaris-auth-handover"
                     package: $(Pipeline.Workspace)/PolarisBuild/polaris-auth-handover-drop
+                    
+                # Set Log Analytics Archival Period - remove when supported natively by Terraform
+                - bash: |
+                    az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                  displayName: Script > Set Log Analytics Archival Periods
+                  workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
+                  env:
+                    ARM_CLIENT_ID: $(innovation-prod-spn-client-id)
+                    ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
+                    ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
+                    ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    TF_LOG: $(prod-log-level)
                 
                 # Restart app service    
                 - task: AzureAppServiceManage@0

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -647,9 +647,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-dev --workspace-name la-polaris-dev --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -657,6 +657,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-development-spn-secret)
                     ARM_TENANT_ID: $(innovation-development-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-development-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(dev-log-level)
                 
                 # Restart app service - moved away from deployment to buy some time    
@@ -1203,9 +1205,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics-qa --workspace-name la-polaris-qa --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -1213,6 +1215,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-qa-spn-secret)
                     ARM_TENANT_ID: $(innovation-qa-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-qa-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(qa-log-level)
                 
                 # Restart app service    
@@ -1759,9 +1763,9 @@ stages:
                 # Set Log Analytics Archival Period - remove when supported natively by Terraform
                 - bash: |
                     az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
-                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time 90 --total-retention-time 2555 --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppEvents --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppRequests --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
+                    az monitor log-analytics workspace table update --resource-group rg-polaris-analytics --workspace-name la-polaris --name AppServiceConsoleLogs --retention-time $LOG_RETENTION_TIME --total-retention-time $TOTAL_LOG_RETENTION_TIME --subscription $ARM_SUBSCRIPTION_ID
                   displayName: Script > Set Log Analytics Archival Periods
                   workingDirectory: $(Pipeline.Workspace)/PolarisBuild/ui-terraform-files
                   env:
@@ -1769,6 +1773,8 @@ stages:
                     ARM_CLIENT_SECRET: $(innovation-prod-spn-secret)
                     ARM_TENANT_ID: $(innovation-prod-spn-tenant-id)
                     ARM_SUBSCRIPTION_ID: $(innovation-prod-subscription-id)
+                    LOG_RETENTION_TIME: $(log-retention-time)
+                    TOTAL_LOG_RETENTION_TIME: $(total-log-retention-time)
                     TF_LOG: $(prod-log-level)
                 
                 # Restart app service    


### PR DESCRIPTION
Sets the total retention time of the 3 Log Analytics tables (AppEvents, AppRequests and AppServiceConsoleLogs) to 7 years (2555 days). Can only set the max period to 6 years instead of 7 at the moment through the az cli because of a bug - the command is currently in beta and I will alter when fixed by the Microsoft Dev Team.