### PR TITLE
Fix to tag update process and separated the commit report creation to separate stages

### DIFF
--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -820,7 +820,7 @@ stages:
               targetType: 'inline'
               script: |
                 git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
-            displayName: Generate commit report for DEV
+            displayName: Generate commit report for PROD
 
           - task: PublishPipelineArtifact@1
             inputs:

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -246,11 +246,11 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_DEV_Tag
-    displayName: Update Tag > DEV
+  - stage: Create_DEV_Report
+    displayName: Create Report > DEV
     dependsOn: Check_DEV
     jobs:
-      - job: Update_DEV_Tag
+      - job: Create_DEV_Report
         pool:
           vmImage: ubuntu-latest
         steps:
@@ -263,13 +263,32 @@ stages:
               script: |
                 git log dev...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-dev.csv
             displayName: Generate commit report for DEV
-
+            
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
-
+            condition: succeeded()
+            
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV ($(System.JobAttempt))"
+            displayName: "Publish Commit report for DEV"
+            condition: not(succeeded())
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Create_DEV_Report
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+          
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -279,7 +298,7 @@ stages:
 
                 git push origin :refs/tags/dev
                 git tag -f dev
-                git push origin --tags 
+                git push origin dev 
             displayName: Updating the dev tag
             
   - stage: Apply_QA
@@ -506,17 +525,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_QA_Tag
-    displayName: Update Tag > QA
+  - stage: Create_QA_Report
+    displayName: Create Report > QA
     dependsOn: Check_QA
     jobs:
-      - job: Update_QA_Tag
+      - job: Create_QA_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -529,7 +548,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
+              artifact: "Commit Report - QA ($(System.JobAttempt))"
+            displayName: "Publish Commit report for QA"
+            condition: not(succeeded())
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Create_QA_Report
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -539,7 +577,7 @@ stages:
                 
                 git push origin :refs/tags/qa
                 git tag -f qa
-                git push origin --tags 
+                git push origin qa 
             displayName: Updating the qa tag
             
   - stage: Apply_PROD
@@ -766,9 +804,41 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
+  - stage: Create_PROD_Report
+    displayName: Create Report > PROD
+    dependsOn: Check_PROD
+    jobs:
+      - job: Create_PROD_Report
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+            condition: succeeded()
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD ($(System.JobAttempt))"
+            displayName: "Publish Commit report for PROD"
+            condition: not(succeeded())
+                
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD
-    dependsOn: Check_PROD
+    dependsOn: Create_PROD_Report
     jobs:
       - job: Update_PROD_Tag
         pool:
@@ -781,23 +851,10 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
-            displayName: Generate commit report for PROD
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-
-          - task: PowerShell@2
-            inputs:
-              targetType: 'inline'
-              script: |
                 git config user.name "$BUILD_REQUESTEDFOR"
                 git config user.email "$BUILD_REQUESTEDFOREMAIL"
                 
                 git push origin :refs/tags/prod
                 git tag -f prod
-                git push origin --tags 
+                git push origin prod 
             displayName: Updating the prod tag

--- a/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-codebase-only-release-pipeline.yml
@@ -267,16 +267,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
-              artifact: "Commit Report - DEV"
-            displayName: "Publish Commit report for DEV"
-            condition: succeeded()
-            
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV ($(System.JobAttempt))"
             displayName: "Publish Commit report for DEV"
-            condition: not(succeeded())
                 
   - stage: Update_DEV_Tag
     displayName: Update Tag > DEV
@@ -546,16 +538,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
-              artifact: "Commit Report - QA"
-            displayName: "Publish Commit report for QA"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA ($(System.JobAttempt))"
             displayName: "Publish Commit report for QA"
-            condition: not(succeeded())
                 
   - stage: Update_QA_Tag
     displayName: Update Tag > QA
@@ -825,16 +809,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD ($(System.JobAttempt))"
             displayName: "Publish Commit report for PROD"
-            condition: not(succeeded())
                 
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -470,16 +470,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
-              artifact: "Commit Report - DEV"
-            displayName: "Publish Commit report for DEV"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV ($(System.JobAttempt))"
             displayName: "Publish Commit report for DEV"
-            condition: not(succeeded())
                 
   - stage: Update_DEV_Tag
     displayName: Update Tag > DEV
@@ -952,16 +944,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
-              artifact: "Commit Report - QA"
-            displayName: "Publish Commit report for QA"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA ($(System.JobAttempt))"
             displayName: "Publish Commit report for QA"
-            condition: not(succeeded())
                 
   - stage: Update_QA_Tag
     displayName: Update Tag > QA
@@ -1434,16 +1418,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD ($(System.JobAttempt))"
             displayName: "Publish Commit report for PROD"
-            condition: not(succeeded())
                 
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD

--- a/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-terraform-release-pipeline.yml
@@ -449,17 +449,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_DEV_Tag
-    displayName: Update Tag > DEV
+  - stage: Create_DEV_Report
+    displayName: Create Report > DEV
     dependsOn: Check_DEV
     jobs:
-      - job: Update_DEV_Tag
+      - job: Create_DEV_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -472,6 +472,25 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
+            condition: succeeded()
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV ($(System.JobAttempt))"
+            displayName: "Publish Commit report for DEV"
+            condition: not(succeeded())
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Create_DEV_Report
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
 
           - task: PowerShell@2
             inputs:
@@ -482,7 +501,7 @@ stages:
                 
                 git push origin :refs/tags/dev
                 git tag -f dev
-                git push origin --tags 
+                git push origin dev 
             displayName: Updating the dev tag
             
   - stage: Apply_QA
@@ -912,17 +931,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_QA_Tag
-    displayName: Update Tag > QA
+  - stage: Create_QA_Report
+    displayName: Create Report > QA
     dependsOn: Check_QA
     jobs:
-      - job: Update_QA_Tag
+      - job: Create_QA_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -935,7 +954,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
+              artifact: "Commit Report - QA ($(System.JobAttempt))"
+            displayName: "Publish Commit report for QA"
+            condition: not(succeeded())
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Create_QA_Report
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -945,7 +983,7 @@ stages:
                 
                 git push origin :refs/tags/qa
                 git tag -f qa
-                git push origin --tags 
+                git push origin qa 
             displayName: Updating the qa tag
             
   - stage: Apply_PROD
@@ -1374,18 +1412,18 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
-                
-  - stage: Update_PROD_Tag
-    displayName: Update Tag > PROD
+
+  - stage: Create_PROD_Report
+    displayName: Create Report > PROD
     dependsOn: Check_PROD
     jobs:
-      - job: Update_PROD_Tag
+      - job: Create_PROD_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1398,7 +1436,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD"
             displayName: "Publish Commit report for PROD"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD ($(System.JobAttempt))"
+            displayName: "Publish Commit report for PROD"
+            condition: not(succeeded())
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Create_PROD_Report
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1408,5 +1465,5 @@ stages:
                 
                 git push origin :refs/tags/prod
                 git tag -f prod
-                git push origin --tags 
+                git push origin prod 
             displayName: Updating the prod tag

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -338,16 +338,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
-              artifact: "Commit Report - DEV"
-            displayName: "Publish Commit report for DEV"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV ($(System.JobAttempt))"
             displayName: "Publish Commit report for DEV"
-            condition: not(succeeded())
                 
   - stage: Update_DEV_Tag
     displayName: Update Tag > DEV
@@ -688,16 +680,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
-              artifact: "Commit Report - QA"
-            displayName: "Publish Commit report for QA"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA ($(System.JobAttempt))"
             displayName: "Publish Commit report for QA"
-            condition: not(succeeded())
                 
   - stage: Update_QA_Tag
     displayName: Update Tag > QA
@@ -1038,16 +1022,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD ($(System.JobAttempt))"
             displayName: "Publish Commit report for PROD"
-            condition: not(succeeded())
                 
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD

--- a/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
+++ b/polaris-devops-pipelines/manual/polaris-manual-ui-only-terraform-release-pipeline.yml
@@ -317,17 +317,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_DEV_Tag
-    displayName: Update Tag > DEV
+  - stage: Create_DEV_Report
+    displayName: Create Report > DEV
     dependsOn: Check_DEV
     jobs:
-      - job: Update_DEV_Tag
+      - job: Create_DEV_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -340,7 +340,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV ($(System.JobAttempt))"
+            displayName: "Publish Commit report for DEV"
+            condition: not(succeeded())
+                
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Create_DEV_Report
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -350,7 +369,7 @@ stages:
                 
                 git push origin :refs/tags/dev
                 git tag -f dev
-                git push origin --tags 
+                git push origin dev 
             displayName: Updating the dev tag
             
   - stage: Apply_QA
@@ -648,17 +667,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_QA_Tag
-    displayName: Update Tag > QA
+  - stage: Create_QA_Report
+    displayName: Create Report > QA
     dependsOn: Check_QA
     jobs:
-      - job: Update_QA_Tag
+      - job: Create_QA_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -671,7 +690,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
+              artifact: "Commit Report - QA ($(System.JobAttempt))"
+            displayName: "Publish Commit report for QA"
+            condition: not(succeeded())
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Create_QA_Report
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -681,7 +719,7 @@ stages:
                 
                 git push origin :refs/tags/qa
                 git tag -f qa
-                git push origin --tags 
+                git push origin qa 
             displayName: Updating the qa tag
                     
   - stage: Apply_PROD
@@ -979,17 +1017,17 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_PROD_Tag
-    displayName: Update Tag > PROD
+  - stage: Create_PROD_Report
+    displayName: Create Report > PROD
     dependsOn: Check_PROD
     jobs:
-      - job: Update_PROD_Tag
+      - job: Create_PROD_Report
         pool:
           vmImage: ubuntu-latest
         steps:
           - checkout: self
             persistCredentials: true
-            
+
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1002,7 +1040,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD"
             displayName: "Publish Commit report for PROD"
+            condition: succeeded()
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD ($(System.JobAttempt))"
+            displayName: "Publish Commit report for PROD"
+            condition: not(succeeded())
+                
+  - stage: Update_PROD_Tag
+    displayName: Update Tag > PROD
+    dependsOn: Create_PROD_Report
+    jobs:
+      - job: Update_PROD_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+            
           - task: PowerShell@2
             inputs:
               targetType: 'inline'
@@ -1012,5 +1069,5 @@ stages:
                 
                 git push origin :refs/tags/prod
                 git tag -f prod
-                git push origin --tags 
+                git push origin prod 
             displayName: Updating the prod tag

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -876,16 +876,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
-              artifact: "Commit Report - DEV"
-            displayName: "Publish Commit report for DEV"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV ($(System.JobAttempt))"
             displayName: "Publish Commit report for DEV"
-            condition: not(succeeded())
 
   - stage: Update_DEV_Tag
     displayName: Update Tag > DEV
@@ -1453,16 +1445,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
-              artifact: "Commit Report - QA"
-            displayName: "Publish Commit report for QA"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA ($(System.JobAttempt))"
             displayName: "Publish Commit report for QA"
-            condition: not(succeeded())
                 
   - stage: Update_QA_Tag
     displayName: Update Tag > QA
@@ -2030,16 +2014,8 @@ stages:
           - task: PublishPipelineArtifact@1
             inputs:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-            condition: succeeded()
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
               artifact: "Commit Report - PROD ($(System.JobAttempt))"
             displayName: "Publish Commit report for PROD"
-            condition: not(succeeded())
                 
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -854,13 +854,12 @@ stages:
                 -Retries $(status-check-retries)
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
-
-  - stage: Update_DEV_Tag
-    displayName: Update Tag > DEV
+                
+  - stage: Create_DEV_Report
+    displayName: Create Report > DEV
     dependsOn: Check_DEV
-    condition: succeeded()
     jobs:
-      - job: Update_DEV_Tag
+      - job: Create_DEV_Report
         pool:
           vmImage: ubuntu-latest
         steps:
@@ -879,6 +878,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
               artifact: "Commit Report - DEV"
             displayName: "Publish Commit report for DEV"
+            condition: succeeded()
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-dev.csv"
+              artifact: "Commit Report - DEV ($(System.JobAttempt))"
+            displayName: "Publish Commit report for DEV"
+            condition: not(succeeded())
+
+  - stage: Update_DEV_Tag
+    displayName: Update Tag > DEV
+    dependsOn: Check_DEV
+    condition: succeeded()
+    jobs:
+      - job: Update_DEV_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
 
           - task: PowerShell@2
             inputs:
@@ -889,7 +908,7 @@ stages:
                 
                 git push origin :refs/tags/dev
                 git tag -f dev
-                git push origin --tags
+                git push origin dev
             displayName: Updating the dev tag        
                     
   - stage: Run_e2e_Tests_DEV
@@ -1413,12 +1432,11 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
-  - stage: Update_QA_Tag
-    displayName: Update Tag > QA
+  - stage: Create_QA_Report
+    displayName: Create Report > QA
     dependsOn: Check_QA
-    condition: succeeded()
     jobs:
-      - job: Update_QA_Tag
+      - job: Create_QA_Report
         pool:
           vmImage: ubuntu-latest
         steps:
@@ -1437,6 +1455,26 @@ stages:
               targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
               artifact: "Commit Report - QA"
             displayName: "Publish Commit report for QA"
+            condition: succeeded()
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-qa.csv"
+              artifact: "Commit Report - QA ($(System.JobAttempt))"
+            displayName: "Publish Commit report for QA"
+            condition: not(succeeded())
+                
+  - stage: Update_QA_Tag
+    displayName: Update Tag > QA
+    dependsOn: Create_QA_Report
+    condition: succeeded()
+    jobs:
+      - job: Update_QA_Tag
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
 
           - task: PowerShell@2
             inputs:
@@ -1447,7 +1485,7 @@ stages:
                 
                 git push origin :refs/tags/qa
                 git tag -f qa
-                git push origin --tags 
+                git push origin qa 
             displayName: Updating the qa tag
             
   - stage: Run_e2e_Tests_QA
@@ -1971,9 +2009,41 @@ stages:
                 -SecondsDelay $(status-check-delay-seconds)
                 -TimeoutSec $(status-check-timeout-seconds)
                 
+  - stage: Create_PROD_Report
+    displayName: Create Report > PROD
+    dependsOn: Check_PROD
+    jobs:
+      - job: Create_PROD_Report
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
+            displayName: Generate commit report for DEV
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD"
+            displayName: "Publish Commit report for PROD"
+            condition: succeeded()
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
+              artifact: "Commit Report - PROD ($(System.JobAttempt))"
+            displayName: "Publish Commit report for PROD"
+            condition: not(succeeded())
+                
   - stage: Update_PROD_Tag
     displayName: Update Tag > PROD
-    dependsOn: Check_PROD
+    dependsOn: Create_PROD_Report
     condition: succeeded()
     jobs:
       - job: Update_PROD_Tag
@@ -1987,25 +2057,12 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
-            displayName: Generate commit report for PROD
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(Build.Repository.LocalPath)/commit-report-prod.csv"
-              artifact: "Commit Report - PROD"
-            displayName: "Publish Commit report for PROD"
-
-          - task: PowerShell@2
-            inputs:
-              targetType: 'inline'
-              script: |
                 git config user.name "$BUILD_REQUESTEDFOR"
                 git config user.email "$BUILD_REQUESTEDFOREMAIL"
                 
                 git push origin :refs/tags/prod
                 git tag -f prod
-                git push origin --tags 
+                git push origin prod 
             displayName: Updating the prod tag
             
   - stage: Run_e2e_Tests_PROD

--- a/polaris-devops-pipelines/polaris-release-pipeline.yml
+++ b/polaris-devops-pipelines/polaris-release-pipeline.yml
@@ -2025,7 +2025,7 @@ stages:
               targetType: 'inline'
               script: |
                 git log prod...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-prod.csv
-            displayName: Generate commit report for DEV
+            displayName: Generate commit report for PROD
 
           - task: PublishPipelineArtifact@1
             inputs:


### PR DESCRIPTION
Push tag by tag name only allow and allow commit reports to be created with unique jobid(s) to allow for the retry of stages (only if the retry functionality is used - by default, this is not used)