### PR TITLE
set the content disposition on sas link

### DIFF
--- a/polaris-terraform/ui-terraform/nginx.conf
+++ b/polaris-terraform/ui-terraform/nginx.conf
@@ -238,6 +238,7 @@ http {
     }
 
     location /sas-url/ {
+      add_header Content-Disposition: inline;
       proxy_pass https://${SAS_URL_DOMAIN_NAME}/;
     }
 


### PR DESCRIPTION
set the content disposition on sas link to be `inline` https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition