### PR TITLE
Added a range modifier to status checks

### DIFF
--- a/polaris-devops-pipelines/scripts/InvokeRequestWithRetry.ps1
+++ b/polaris-devops-pipelines/scripts/InvokeRequestWithRetry.ps1
@@ -11,8 +11,20 @@ param (
 )
 
 $AdjustedSuccessTextContent = $SuccessTextContent.replace('-ci', '').replace('-man', '')
+$AdjustedSuccessTextContentWithoutVersion = $AdjustedSuccessTextContent.Substring(0, $AdjustedSuccessTextContent.LastIndexOf('.'))
+$PotentialVersionNumberText = $AdjustedSuccessTextContent.Substring($AdjustedSuccessTextContent.LastIndexOf('.')+1, $AdjustedSuccessTextContent.Length - $AdjustedSuccessTextContent.LastIndexOf('.')-1)
+$PotentialVersionNumber1 = [int32]$PotentialVersionNumberText + 1
+$PotentialVersionNumber2 = [int32]$PotentialVersionNumberText + 2
+$PotentialVersionNumber3 = [int32]$PotentialVersionNumberText + 3
+$PotentialVersionNumber4 = [int32]$PotentialVersionNumberText + 4
+$PotentialVersionNumber5 = [int32]$PotentialVersionNumberText + 5
+$PotentialSuccessTextContent1 = $AdjustedSuccessTextContentWithoutVersion + '.' + $PotentialVersionNumber1
+$PotentialSuccessTextContent2 = $AdjustedSuccessTextContentWithoutVersion + '.' + $PotentialVersionNumber2
+$PotentialSuccessTextContent3 = $AdjustedSuccessTextContentWithoutVersion + '.' + $PotentialVersionNumber3
+$PotentialSuccessTextContent4 = $AdjustedSuccessTextContentWithoutVersion + '.' + $PotentialVersionNumber4
+$PotentialSuccessTextContent5 = $AdjustedSuccessTextContentWithoutVersion + '.' + $PotentialVersionNumber5
 
-Write-Output "$Method ""$URI"" Retries: $Retries, SecondsDelay $SecondsDelay, TimeoutSec $TimeoutSec, ExpectedVersion $AdjustedSuccessTextContent";
+Write-Output "$Method ""$URI"" Retries: $Retries, SecondsDelay $SecondsDelay, TimeoutSec $TimeoutSec, ExpectedVersionMin $AdjustedSuccessTextContent, ExpectedVersionMax $PotentialSuccessTextContent5";
 
 Function Req {
     Param(
@@ -43,14 +55,14 @@ Function Req {
             }
             else 
             {
-                if($response.Content -like "*$AdjustedSuccessTextContent*")
+                if($response.Content -like "*$AdjustedSuccessTextContent*" -Or $response.Content -like "*$PotentialSuccessTextContent1*" -Or $response.Content -like "*$PotentialSuccessTextContent2*" -Or $response.Content -like "*$PotentialSuccessTextContent3*" -Or $response.Content -like "*$PotentialSuccessTextContent4*" -Or $response.Content -like "*$PotentialSuccessTextContent5*")
                 {
-                    Write-Host "Health check validation success - '$AdjustedSuccessTextContent' found."
+                    Write-Host "Health check validation success - version range between '$AdjustedSuccessTextContent' and '$PotentialSuccessTextContent5' found."
                     $completed = $true
                 }
                 else
                 {
-                    Write-Warning "Invalid version found - expecting content to contain '$AdjustedSuccessTextContent', received '$response.Content'"
+                    Write-Warning "Invalid version found - expecting content to a version ranged between '$AdjustedSuccessTextContent' and '$PotentialSuccessTextContent5'; received '$response.Content' instead."
                 }
             }
             
@@ -85,11 +97,11 @@ try
     $res = Req -Retries $Retries -SecondsDelay $SecondsDelay -Params @{ 'Method' = $Method; 'Uri' = $URI; 'TimeoutSec' = $TimeoutSec; 'UseBasicParsing' = $true }
     if($res -eq $true)
     {
-        Write-Host "Health check validation success - '$AdjustedSuccessTextContent' found."
+        Write-Host "Health check validation success - a version between a range of '$AdjustedSuccessTextContent' or '$PotentialSuccessTextContent5' was found."
     }
     else
     {
-        Write-Error "Health check validation failed - '$AdjustedSuccessTextContent' was never found."
+        Write-Error "Health check validation failed - a version falling between the range of '$AdjustedSuccessTextContent' or '$PotentialSuccessTextContent5' was never received."
     }
 }
 catch 


### PR DESCRIPTION
This change allows for an app to be deployed in competing releases before a current deployment and its checks have been completed. This change allows for another 4 version number increments to determine safety to proceed.