### PR TITLE
#23489 - Changed logging level for app functions to Information

### DIFF
--- a/polaris-pipeline/coordinator/host.json
+++ b/polaris-pipeline/coordinator/host.json
@@ -3,13 +3,13 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "Warning",
+      "default": "Information",
       "Function": "Information",
-      "Host.Aggregator": "Error",
+      "Host.Aggregator": "Information",
       "Host.Results": "Information",
-      "Host.Triggers.DurableTask": "Warning",
-      "DurableTask.AzureStorage": "Warning",
-      "DurableTask.Core": "Warning"
+      "Host.Triggers.DurableTask": "Information",
+      "DurableTask.AzureStorage": "Information",
+      "DurableTask.Core": "Information"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/polaris-pipeline/pdf-generator/host.json
+++ b/polaris-pipeline/pdf-generator/host.json
@@ -3,13 +3,13 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "Warning",
+      "default": "Information",
       "Function": "Information",
-      "Host.Aggregator": "Error",
+      "Host.Aggregator": "Information",
       "Host.Results": "Information",
-      "Host.Triggers.DurableTask": "Warning",
-      "DurableTask.AzureStorage": "Warning",
-      "DurableTask.Core": "Warning"
+      "Host.Triggers.DurableTask": "Information",
+      "DurableTask.AzureStorage": "Information",
+      "DurableTask.Core": "Information"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/polaris-pipeline/text-extractor/host.json
+++ b/polaris-pipeline/text-extractor/host.json
@@ -3,13 +3,13 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "Trace",
-      "Function": "Trace",
-      "Host.Aggregator": "Trace",
-      "Host.Results": "Trace",
-      "Host.Triggers.DurableTask": "Trace",
-      "DurableTask.AzureStorage": "Trace",
-      "DurableTask.Core": "Trace"
+      "default": "Information",
+      "Function": "Information",
+      "Host.Aggregator": "Information",
+      "Host.Results": "Information",
+      "Host.Triggers.DurableTask": "Information",
+      "DurableTask.AzureStorage": "Information",
+      "DurableTask.Core": "Information"
     },
     "applicationInsights": {
       "samplingSettings": {


### PR DESCRIPTION
This PR standardises the three Polaris function apps to log at the "Information". The apps now export logs to Log Analytics but until this change goes in, only the Text Extractor logs are visible (and those are too verbose because it is set to "Trace").  The ultimate aim is to have better tracing/correlation across orchestrator and sub-orchestrator boundaries.