### PR TITLE
Bugfix/24145 aspose unlicensed for some redactions

### DIFF
--- a/polaris-pipeline/pdf-generator/Services/PdfService/CellsPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/CellsPdfService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Aspose.Cells;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService
@@ -12,16 +11,6 @@ namespace pdf_generator.Services.PdfService
 
         public CellsPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/DiagramPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/DiagramPdfService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Aspose.Diagram;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService
@@ -12,16 +11,6 @@ namespace pdf_generator.Services.PdfService
 
         public DiagramPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/EmailPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/EmailPdfService.cs
@@ -2,9 +2,7 @@
 using System.IO;
 using Aspose.Email;
 using Aspose.Words;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
-using License = Aspose.Email.License;
 
 namespace pdf_generator.Services.PdfService
 {
@@ -14,16 +12,6 @@ namespace pdf_generator.Services.PdfService
 
         public EmailPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/HtmlPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/HtmlPdfService.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.IO;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
-using License = Aspose.Pdf.License;
 
 namespace pdf_generator.Services.PdfService
 {
@@ -12,16 +10,6 @@ namespace pdf_generator.Services.PdfService
 
         public HtmlPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/ImagingPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/ImagingPdfService.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.IO;
-using Aspose.Imaging;
 using Aspose.Imaging.FileFormats.Pdf;
 using Aspose.Imaging.ImageOptions;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService
@@ -14,16 +12,6 @@ namespace pdf_generator.Services.PdfService
 
         public ImagingPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/PdfRendererService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/PdfRendererService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Aspose.Pdf;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService;
@@ -12,16 +11,6 @@ public class PdfRendererService : IPdfService
 
     public PdfRendererService(IAsposeItemFactory asposeItemFactory)
     {
-        try
-        {
-            var license = new License();
-            license.SetLicense("Aspose.Total.NET.lic");
-        }
-        catch (Exception exception)
-        {
-            throw new AsposeLicenseException(exception.Message);
-        }
-
         _asposeItemFactory = asposeItemFactory;
     }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/SlidesPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/SlidesPdfService.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.IO;
-using Aspose.Slides;
 using Aspose.Slides.Export;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService
@@ -13,16 +11,6 @@ namespace pdf_generator.Services.PdfService
 
         public SlidesPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory ?? throw new ArgumentNullException(nameof(asposeItemFactory));
         }
 

--- a/polaris-pipeline/pdf-generator/Services/PdfService/WordsPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/WordsPdfService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Aspose.Words;
-using pdf_generator.Domain.Exceptions;
 using pdf_generator.Factories.Contracts;
 
 namespace pdf_generator.Services.PdfService
@@ -12,16 +11,6 @@ namespace pdf_generator.Services.PdfService
 
         public WordsPdfService(IAsposeItemFactory asposeItemFactory)
         {
-            try
-            {
-                var license = new License();
-                license.SetLicense("Aspose.Total.NET.lic");
-            }
-            catch (Exception exception)
-            {
-                throw new AsposeLicenseException(exception.Message);
-            }
-
             _asposeItemFactory = asposeItemFactory;
         }
 

--- a/polaris-pipeline/pdf-generator/Startup.cs
+++ b/polaris-pipeline/pdf-generator/Startup.cs
@@ -31,7 +31,7 @@ namespace pdf_generator
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            SetAsposeLicense();
+            SetAsposeLicence();
 
             var services = builder.Services;
             services.AddSingleton<IConfiguration>(Configuration);
@@ -60,7 +60,7 @@ namespace pdf_generator
                  .AddCheck<AzureBlobServiceClientHealthCheck>("Azure Blob Service Client");
         }
 
-        private static void SetAsposeLicense()
+        private static void SetAsposeLicence()
         {
             try
             {

--- a/polaris-pipeline/pdf-generator/Startup.cs
+++ b/polaris-pipeline/pdf-generator/Startup.cs
@@ -20,6 +20,8 @@ using Common.Telemetry.Contracts;
 using Common.Telemetry;
 using pdf_generator.Services.DocumentRedactionService.RedactionProvider;
 using pdf_generator.Services.DocumentRedactionService.RedactionProvider.ImageConversion;
+using System;
+using pdf_generator.Domain.Exceptions;
 
 [assembly: FunctionsStartup(typeof(pdf_generator.Startup))]
 namespace pdf_generator
@@ -29,8 +31,9 @@ namespace pdf_generator
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            var services = builder.Services;
+            SetAsposeLicense();
 
+            var services = builder.Services;
             services.AddSingleton<IConfiguration>(Configuration);
             services.Configure<ImageConversionOptions>(Configuration.GetSection(ImageConversionOptions.ConfigKey));
             services.AddBlobStorageWithDefaultAzureCredential(Configuration);
@@ -55,6 +58,25 @@ namespace pdf_generator
             services.AddHealthChecks()
                  .AddCheck<AzureSearchClientHealthCheck>("Azure Search Client")
                  .AddCheck<AzureBlobServiceClientHealthCheck>("Azure Blob Service Client");
+        }
+
+        private static void SetAsposeLicense()
+        {
+            try
+            {
+                var licenceFileName = "Aspose.Total.NET.lic";
+                new Aspose.Cells.License().SetLicense(licenceFileName);
+                new Aspose.Diagram.License().SetLicense(licenceFileName);
+                new Aspose.Email.License().SetLicense(licenceFileName);
+                new Aspose.Imaging.License().SetLicense(licenceFileName);
+                new Aspose.Pdf.License().SetLicense(licenceFileName);
+                new Aspose.Slides.License().SetLicense(licenceFileName);
+                new Aspose.Words.License().SetLicense(licenceFileName);
+            }
+            catch (Exception exception)
+            {
+                throw new AsposeLicenseException(exception.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
90% sure that this fixes #24145.  

Prior to this fix the `Aspose.Pdf` licence was set only in the constructor of `PdfRendererService`.  For any given dotnet app process that had spun up, redaction done by `DocumentRedactionService` was licensed only if a pdf conversion had been previously done by that process (and hence had the chance to set the licence). If a redaction was done by the given process before a conversion had been processed the redaction was not licensed and so the evaluation banner appears in the redacted document.

This fixes lifts the licensing up into `Startup.cs` and so avoids two separate service constructors having to set the same licence.

