### PR TITLE
Removed unnecessary client config key as the SPA will be presenting i…

### DIFF
--- a/polaris-terraform/ui-terraform/app-service.tf
+++ b/polaris-terraform/ui-terraform/app-service.tf
@@ -27,11 +27,10 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG" = "1"
     "APPINSIGHTS_INSTRUMENTATIONKEY"                  = data.azurerm_application_insights.global_ai.instrumentation_key
     "REACT_APP_CLIENT_ID"                             = module.azurerm_app_reg_as_web_polaris.client_id
-    "REACT_APP_REDACTION_LOG_CLIENT_ID"               = data.azuread_application.fa_redaction_log_reporting.application_id
     "REACT_APP_TENANT_ID"                             = data.azurerm_client_config.current.tenant_id
     "REACT_APP_GATEWAY_BASE_URL"                      = ""
     "REACT_APP_GATEWAY_SCOPE"                         = "https://CPSGOVUK.onmicrosoft.com/${azurerm_linux_function_app.fa_polaris.name}/user_impersonation"
-    "REACT_APP_GATEWAY_BASE_URL"                      = "https://fa-${local.redaction_log_resource_name}-reporting.azurewebsites.net"
+    "REACT_APP_REDACTION_LOG_BASE_URL"                = "https://fa-${local.redaction_log_resource_name}-reporting.azurewebsites.net"
     "REACT_APP_REDACTION_LOG_SCOPE"                   = "https://CPSGOVUK.onmicrosoft.com/fa-${local.redaction_log_resource_name}-reporting/user_impersonation"
     "REACT_APP_REAUTH_REDIRECT_URL"                   = "/polaris?polaris-ui-url="
     "REACT_APP_AI_KEY"                                = data.azurerm_application_insights.global_ai.instrumentation_key

--- a/polaris-ui/public/run-substitution.sh
+++ b/polaris-ui/public/run-substitution.sh
@@ -3,8 +3,8 @@ PUBLIC_URL=/polaris-ui \
 REACT_APP_CLIENT_ID=3649c1c8-00cf-4b8f-a671-304bc074937c \
 REACT_APP_TENANT_ID=00dd0d1d-d7e6-4338-ac51-565339c7088c \
 REACT_APP_GATEWAY_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-polaris-dev-gateway/user_impersonation \
-REACT_APP_REDACTION_LOG_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-redaction-log-dev-reporting/user_impersonation \
 REACT_APP_GATEWAY_BASE_URL=https://polaris-dev-cmsproxy.azurewebsites.net \
+REACT_APP_REDACTION_LOG_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-redaction-log-dev-reporting/user_impersonation \
 REACT_APP_REDACTION_LOG_BASE_URL=https://fa-redaction-log-dev-reporting.azurewebsites.net \
 REACT_APP_REAUTH_REDIRECT_URL=https://polaris-dev-cmsproxy.azurewebsites.net/polaris?polaris-ui-url= \
 REACT_APP_MOCK_AUTH=false \

--- a/polaris-ui/public/run-substitution.sh
+++ b/polaris-ui/public/run-substitution.sh
@@ -3,7 +3,9 @@ PUBLIC_URL=/polaris-ui \
 REACT_APP_CLIENT_ID=3649c1c8-00cf-4b8f-a671-304bc074937c \
 REACT_APP_TENANT_ID=00dd0d1d-d7e6-4338-ac51-565339c7088c \
 REACT_APP_GATEWAY_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-polaris-dev-gateway/user_impersonation \
+REACT_APP_REDACTION_LOG_SCOPE=https://CPSGOVUK.onmicrosoft.com/fa-redaction-log-dev-reporting/user_impersonation \
 REACT_APP_GATEWAY_BASE_URL=https://polaris-dev-cmsproxy.azurewebsites.net \
+REACT_APP_REDACTION_LOG_BASE_URL=https://fa-redaction-log-dev-reporting.azurewebsites.net \
 REACT_APP_REAUTH_REDIRECT_URL=https://polaris-dev-cmsproxy.azurewebsites.net/polaris?polaris-ui-url= \
 REACT_APP_MOCK_AUTH=false \
 REACT_APP_MOCK_API_SOURCE= \


### PR DESCRIPTION
…tself to the fa-redaction-log-reporting API. Extended the run-substitution.sh script to include the two redaction log api config keys - scope and baseurl.