### PR TITLE
Enable scale controller logging in QA

### DIFF
--- a/polaris-terraform/pipeline-terraform/qa.tfvars
+++ b/polaris-terraform/pipeline-terraform/qa.tfvars
@@ -5,9 +5,9 @@ dns_server      = "10.7.198.164"
 terraform_service_principal_display_name = "Azure Pipeline: Innovation-QA"
 
 pipeline_logging = {
-  coordinator_scale_controller    = "AppInsights:None"
-  pdf_generator_scale_controller  = "AppInsights:None"
-  text_extractor_scale_controller = "AppInsights:None"
+  coordinator_scale_controller    = "AppInsights:Verbose"
+  pdf_generator_scale_controller  = "AppInsights:Verbose"
+  text_extractor_scale_controller = "AppInsights:Verbose"
 }
 
 pipeline_component_service_plans = {

--- a/polaris-terraform/ui-terraform/app-service.tf
+++ b/polaris-terraform/ui-terraform/app-service.tf
@@ -31,6 +31,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     "REACT_APP_REDACTION_LOG_SCOPE"                   = "https://CPSGOVUK.onmicrosoft.com/fa-${local.redaction_log_resource_name}-reporting/user_impersonation"
     "REACT_APP_SURVEY_LINK"                           = "https://www.smartsurvey.co.uk/s/DG5B6G/"
     "REACT_APP_TENANT_ID"                             = data.azurerm_client_config.current.tenant_id
+    "SCALE_CONTROLLER_LOGGING_ENABLED"                = var.ui_logging.ui_scale_controller
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG" = "1"
     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"        = azurerm_storage_account.sacpspolaris.primary_connection_string
     "WEBSITE_CONTENTOVERVNET"                         = "1"

--- a/polaris-terraform/ui-terraform/auth-handover-function.tf
+++ b/polaris-terraform/ui-terraform/auth-handover-function.tf
@@ -18,7 +18,6 @@ resource "azurerm_linux_function_app" "fa_polaris_auth_handover" {
     "FUNCTIONS_EXTENSION_VERSION"                     = "~4"
     "FUNCTIONS_WORKER_RUNTIME"                        = "dotnet"
     "HostType"                                        = "Production"
-    "SCALE_CONTROLLER_LOGGING_ENABLED"                = var.ui_logging.auth_handover_scale_controller
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG" = "1"
     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"        = azurerm_storage_account.sacpspolaris.primary_connection_string
     "WEBSITE_CONTENTOVERVNET"                         = "1"

--- a/polaris-terraform/ui-terraform/dev.tfvars
+++ b/polaris-terraform/ui-terraform/dev.tfvars
@@ -17,7 +17,7 @@ terraform_service_principal_display_name = "Azure Pipeline: Innovation-Developme
 ui_logging = {
   gateway_scale_controller       = "AppInsights:Verbose"
   auth_handover_scale_controller = "AppInsights:Verbose"
-  proxy_scale_controller         = "AppInsights:Verbose"
+  ui_scale_controller            = "AppInsights:Verbose"
 }
 
 cms_details = {

--- a/polaris-terraform/ui-terraform/prod.tfvars
+++ b/polaris-terraform/ui-terraform/prod.tfvars
@@ -17,7 +17,7 @@ terraform_service_principal_display_name = "Azure Pipeline: Innovation-Productio
 ui_logging = {
   gateway_scale_controller       = "AppInsights:None"
   auth_handover_scale_controller = "AppInsights:None"
-  proxy_scale_controller         = "AppInsights:None"
+  ui_scale_controller            = "AppInsights:None"
 }
 
 cms_details = {

--- a/polaris-terraform/ui-terraform/proxy.tf
+++ b/polaris-terraform/ui-terraform/proxy.tf
@@ -28,7 +28,6 @@ resource "azurerm_linux_web_app" "polaris_proxy" {
     "XDT_MicrosoftApplicationInsights_PreemptSdk"     = "disabled"
     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"        = azurerm_storage_account.sacpspolaris.primary_connection_string
     "WEBSITE_CONTENTSHARE"                            = azapi_resource.polaris_sacpspolaris_proxy_file_share.name
-    "SCALE_CONTROLLER_LOGGING_ENABLED"                = var.ui_logging.proxy_scale_controller
     "UPSTREAM_CMS_IP_CORSHAM"                         = var.cms_details.upstream_cms_ip_corsham
     "UPSTREAM_CMS_MODERN_IP_CORSHAM"                  = var.cms_details.upstream_cms_modern_ip_corsham
     "UPSTREAM_CMS_IP_FARNBOROUGH"                     = var.cms_details.upstream_cms_ip_farnborough

--- a/polaris-terraform/ui-terraform/qa.tfvars
+++ b/polaris-terraform/ui-terraform/qa.tfvars
@@ -15,9 +15,9 @@ polaris_webapp_details = {
 terraform_service_principal_display_name = "Azure Pipeline: Innovation-QA"
 
 ui_logging = {
-  gateway_scale_controller       = "AppInsights:None"
-  auth_handover_scale_controller = "AppInsights:None"
-  proxy_scale_controller         = "AppInsights:None"
+  gateway_scale_controller       = "AppInsights:Verbose"
+  auth_handover_scale_controller = "AppInsights:Verbose"
+  ui_scale_controller            = "AppInsights:Verbose"
 }
 
 cms_details = {

--- a/polaris-terraform/ui-terraform/variables.tf
+++ b/polaris-terraform/ui-terraform/variables.tf
@@ -63,7 +63,7 @@ variable "ui_logging" {
   type = object({
     gateway_scale_controller       = string
     auth_handover_scale_controller = string
-    proxy_scale_controller         = string
+    ui_scale_controller            = string
   })
 }
 


### PR DESCRIPTION
Enable scale controller logging in QA and move scale controller setting from proxy (which doesn't scale) to the UI (SPA).