### PR TITLE
Re-enable sliding-case-clear-down, in dev and qa, with future prep for prod

### DIFF
--- a/polaris-pipeline/Common/Constants/PipelineConstants.cs
+++ b/polaris-pipeline/Common/Constants/PipelineConstants.cs
@@ -79,10 +79,10 @@
         public static class CoordinatorKeys
         {
             public const string CoordinatorOrchestratorTimeoutSecs = "CoordinatorOrchestratorTimeoutSecs";
-            public const string AzureWebJobsStorage = "AzureWebJobsStorage";
             public const string OvernightClearDownEnabled = "OvernightClearDownEnabled";
-            public const string SlidingClearDownEnabled = "SlidingClearDownEnabled";
-            public const string SlidingClearDownInputDays = "SlidingClearDownInputDays";
+            public const string SlidingClearDownEnabled = nameof(SlidingClearDownEnabled);
+            public const string SlidingClearDownInputDays = nameof(SlidingClearDownInputDays);
+            public const string SlidingClearDownProtectBlobs = nameof(SlidingClearDownProtectBlobs);
         }
 
         public static class TextExtractorKeys

--- a/polaris-pipeline/coordinator.tests/Functions/CoordinatorStartTests.cs
+++ b/polaris-pipeline/coordinator.tests/Functions/CoordinatorStartTests.cs
@@ -30,7 +30,6 @@ namespace coordinator.tests.Functions
         private readonly HttpResponseMessage _httpResponseMessage;
 
         private readonly Mock<IDurableOrchestrationClient> _mockDurableOrchestrationClient;
-        private readonly Mock<ILogger<CaseClient>> _mockLogger;
         private readonly Mock<IOrchestrationProvider> _mockOrchestrationProvider;
 
         private readonly CaseClient _coordinatorStart;
@@ -52,7 +51,7 @@ namespace coordinator.tests.Functions
             _httpResponseMessage = new HttpResponseMessage();
 
             _mockDurableOrchestrationClient = new Mock<IDurableOrchestrationClient>();
-            _mockLogger = new Mock<ILogger<CaseClient>>();
+            var mockLogger = new Mock<ILogger<CaseClient>>();
             var mockBlobStorageClient = new Mock<IPolarisBlobStorageService>();
             _mockOrchestrationProvider = new Mock<IOrchestrationProvider>();
 
@@ -72,11 +71,10 @@ namespace coordinator.tests.Functions
                     It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CaseOrchestrationPayload>(), _httpRequestMessage))
                 .ReturnsAsync(_httpResponseMessage);
             _mockOrchestrationProvider.Setup(s => s.DeleteCaseAsync(_mockDurableOrchestrationClient.Object,
-                    It.IsAny<Guid>(), It.IsAny<int>()))
+                    It.IsAny<Guid>(), It.IsAny<int>(), false))
                 .ReturnsAsync(_httpResponseMessage);
 
-            _coordinatorStart = new CaseClient(_mockLogger.Object,
-                                               _mockOrchestrationProvider.Object);
+            _coordinatorStart = new CaseClient(mockLogger.Object, _mockOrchestrationProvider.Object);
         }
 
         [Fact]

--- a/polaris-pipeline/coordinator/Functions/Orchestration/Client/Case/CaseClient.cs
+++ b/polaris-pipeline/coordinator/Functions/Orchestration/Client/Case/CaseClient.cs
@@ -90,7 +90,7 @@ namespace coordinator.Functions.Orchestration.Client.Case
                         return await _orchestrationProvider.RefreshCaseAsync(orchestrationClient, currentCorrelationId, caseId, casePayload, req);
 
                     case "DELETE":
-                        return await _orchestrationProvider.DeleteCaseAsync(orchestrationClient, currentCorrelationId, caseIdNum);
+                        return await _orchestrationProvider.DeleteCaseAsync(orchestrationClient, currentCorrelationId, caseIdNum, false);
 
                     default:
                         throw new BadRequestException("Unexpected HTTP Verb", req.Method.Method);

--- a/polaris-pipeline/coordinator/Functions/Orchestration/Functions/Maintenance/SlidingCaseClearDown.cs
+++ b/polaris-pipeline/coordinator/Functions/Orchestration/Functions/Maintenance/SlidingCaseClearDown.cs
@@ -45,18 +45,15 @@ public class SlidingCaseClearDown
             if (convSucceeded && clearDownEnabled && inputConvSucceeded)
             {
                 var clearDownPeriod = clearDownInputDays * -1;
-                var targetCaseId =
-                    await _orchestrationProvider.FindCaseInstanceByDateAsync(DateTime.UtcNow.AddDays(clearDownPeriod), correlationId);
+                var targetCaseId = await _orchestrationProvider.FindCaseInstanceByDateAsync(DateTime.UtcNow.AddDays(clearDownPeriod), correlationId);
+                
                 if (string.IsNullOrEmpty(targetCaseId))
-                {
                     return;
-                }
-
+                
                 if (!int.TryParse(targetCaseId.Replace("[", "").Replace("]", ""), out var caseId))
-                    throw new InvalidCastException(
-                        $"Invalid case id. A 32-bit integer is expected. A value of {targetCaseId} was found instead");
+                    throw new InvalidCastException($"Invalid case id. A 32-bit integer is expected. A value of {targetCaseId} was found instead");
 
-                var deleteResponse = await _orchestrationProvider.DeleteCaseAsync(client, correlationId, caseId);
+                var deleteResponse = await _orchestrationProvider.DeleteCaseAsync(client, correlationId, caseId, true);
                 deleteResponse.EnsureSuccessStatusCode();
             }
         }

--- a/polaris-pipeline/coordinator/Providers/IOrchestrationProvider.cs
+++ b/polaris-pipeline/coordinator/Providers/IOrchestrationProvider.cs
@@ -14,5 +14,5 @@ public interface IOrchestrationProvider
         string caseId, CaseOrchestrationPayload casePayload, HttpRequestMessage req);
 
     Task<HttpResponseMessage> DeleteCaseAsync(IDurableOrchestrationClient orchestrationClient, Guid correlationId,
-        int caseId);
+        int caseId, bool checkForBlobProtection);
 }

--- a/polaris-terraform/pipeline-terraform/dev.tfvars
+++ b/polaris-terraform/pipeline-terraform/dev.tfvars
@@ -27,9 +27,13 @@ pipeline_component_service_plans = {
 
 overnight_clear_down_enabled = false
 
-sliding_clear_down_enabled    = false
-sliding_clear_down_input_days = 31
-hte_feature_flag              = true
+sliding_clear_down = {
+  enabled        = true
+  look_back_days = 7
+  protect_blobs  = false
+}
+
+hte_feature_flag = true
 
 image_conversion_redaction = {
   resolution      = 150

--- a/polaris-terraform/pipeline-terraform/functions-coordinator-staging.tf
+++ b/polaris-terraform/pipeline-terraform/functions-coordinator-staging.tf
@@ -33,8 +33,9 @@ resource "azurerm_linux_function_app_slot" "fa_coordinator_staging1" {
     "SearchClientAuthorizationKey"                    = azurerm_search_service.ss.primary_key
     "SearchClientEndpointUrl"                         = "https://${azurerm_search_service.ss.name}.search.windows.net"
     "SearchClientIndexName"                           = jsondecode(file("search-index-definition.json")).name
-    "SlidingClearDownEnabled"                         = var.sliding_clear_down_enabled
-    "SlidingClearDownInputDays"                       = var.sliding_clear_down_input_days
+    "SlidingClearDownEnabled"                         = var.sliding_clear_down.enabled
+    "SlidingClearDownInputDays"                       = var.sliding_clear_down.look_back_days
+    "SlidingClearDownProtectBlobs"                    = var.sliding_clear_down.protect_blobs
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG" = "1"
     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"        = azurerm_storage_account.sa_coordinator.primary_connection_string
     "WEBSITE_CONTENTOVERVNET"                         = "1"

--- a/polaris-terraform/pipeline-terraform/functions-coordinator.tf
+++ b/polaris-terraform/pipeline-terraform/functions-coordinator.tf
@@ -37,8 +37,9 @@ resource "azurerm_linux_function_app" "fa_coordinator" {
     "SearchClientAuthorizationKey"                    = azurerm_search_service.ss.primary_key
     "SearchClientEndpointUrl"                         = "https://${azurerm_search_service.ss.name}.search.windows.net"
     "SearchClientIndexName"                           = jsondecode(file("search-index-definition.json")).name
-    "SlidingClearDownEnabled"                         = var.sliding_clear_down_enabled
-    "SlidingClearDownInputDays"                       = var.sliding_clear_down_input_days
+    "SlidingClearDownEnabled"                         = var.sliding_clear_down.enabled
+    "SlidingClearDownInputDays"                       = var.sliding_clear_down.look_back_days
+    "SlidingClearDownProtectBlobs"                    = var.sliding_clear_down.protect_blobs
     "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG" = "1"
     "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING"        = azurerm_storage_account.sa_coordinator.primary_connection_string
     "WEBSITE_CONTENTOVERVNET"                         = "1"
@@ -54,7 +55,7 @@ resource "azurerm_linux_function_app" "fa_coordinator" {
   }
 
   sticky_settings {
-    app_setting_names = ["CoordinatorTaskHub","HostType"]
+    app_setting_names = ["CoordinatorTaskHub", "HostType"]
   }
 
   site_config {

--- a/polaris-terraform/pipeline-terraform/prod.tfvars
+++ b/polaris-terraform/pipeline-terraform/prod.tfvars
@@ -27,9 +27,13 @@ pipeline_component_service_plans = {
 
 overnight_clear_down_enabled = false
 
-sliding_clear_down_enabled    = false
-sliding_clear_down_input_days = 31
-hte_feature_flag              = false
+sliding_clear_down = {
+  enabled        = false
+  look_back_days = 31
+  protect_blobs  = true
+}
+
+hte_feature_flag = false
 
 image_conversion_redaction = {
   resolution      = 150

--- a/polaris-terraform/pipeline-terraform/qa.tfvars
+++ b/polaris-terraform/pipeline-terraform/qa.tfvars
@@ -27,9 +27,13 @@ pipeline_component_service_plans = {
 
 overnight_clear_down_enabled = false
 
-sliding_clear_down_enabled    = false
-sliding_clear_down_input_days = 31
-hte_feature_flag              = true
+sliding_clear_down = {
+  enabled        = true
+  look_back_days = 7
+  protect_blobs  = false
+}
+
+hte_feature_flag = true
 
 image_conversion_redaction = {
   resolution      = 150

--- a/polaris-terraform/pipeline-terraform/variables.tf
+++ b/polaris-terraform/pipeline-terraform/variables.tf
@@ -73,14 +73,6 @@ variable "sliding_clear_down" {
   })
 }
 
-variable "sliding_clear_down_enabled" {
-  type = bool
-}
-
-variable "sliding_clear_down_input_days" {
-  type = number
-}
-
 variable "hte_feature_flag" {
   type = bool
 }

--- a/polaris-terraform/pipeline-terraform/variables.tf
+++ b/polaris-terraform/pipeline-terraform/variables.tf
@@ -65,6 +65,14 @@ variable "overnight_clear_down_enabled" {
   type = bool
 }
 
+variable "sliding_clear_down" {
+  type = object({
+    enabled        = bool
+    look_back_days = number
+    protect_blobs  = bool
+  })
+}
+
 variable "sliding_clear_down_enabled" {
   type = bool
 }

--- a/polaris-terraform/ui-terraform/app-service.tf
+++ b/polaris-terraform/ui-terraform/app-service.tf
@@ -40,7 +40,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     "WEBSITE_OVERRIDE_STICKY_DIAGNOSTICS_SETTINGS"    = "0"
     "WEBSITE_OVERRIDE_STICKY_EXTENSION_VERSIONS"      = "0"
   }
-  
+
   sticky_settings {
     app_setting_names = ["HostType"]
   }


### PR DESCRIPTION
Re-enable sliding-case-clear-down, in dev and qa, with future prep for blob protection in prod while allowing callers of the case client (e.g., e2e tests) to delete blobs