### PR TITLE
Story : 25213 - Bypassing the private beta group access restriction for prod and dev

### DIFF
--- a/polaris-terraform/ui-terraform/dev.tfvars
+++ b/polaris-terraform/ui-terraform/dev.tfvars
@@ -43,6 +43,6 @@ redaction_log_user_group = ""
 
 private_beta = {
   sign_up_url = "https://forms.office.com/e/Af374akw0Q"
-  user_group  = "1a9b08e8-5839-4953-a053-c1bc6dd02233" // the Polaris-Dev-VPN group
+  user_group  = ""
   redaction_log_user_group = "8fc75d71-3479-4a77-b33b-41fd26ec4960" 
 }

--- a/polaris-terraform/ui-terraform/prod.tfvars
+++ b/polaris-terraform/ui-terraform/prod.tfvars
@@ -41,6 +41,6 @@ redaction_log_user_group = ""
 
 private_beta = {
   sign_up_url = "https://forms.office.com/e/Af374akw0Q"
-  user_group  = "4d88565f-227b-4043-995c-038286b79869" // the Polaris-Production Access group
+  user_group  = ""
   redaction_log_user_group = "8fc75d71-3479-4a77-b33b-41fd26ec4960"
 }


### PR DESCRIPTION
https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/25213. As we still want to keep the access restriction feature, just bypassing it in dev and prod with empty string value, just like qa.