### PR TITLE
Fix bug where incoming input stream is handled different under aspnetcore

### DIFF
--- a/polaris-pipeline/pdf-generator.test-harness/Mode.cs
+++ b/polaris-pipeline/pdf-generator.test-harness/Mode.cs
@@ -1,5 +1,8 @@
+namespace pdf_generator.test_harness;
+
 public enum Mode
 {
-    RedactPdf,
-    ConvertToPdf,
+    LibraryCallRedactPdf,
+    LibraryCallConvertToPdf,
+    FunctionCallConvertToPdf
 }

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/CellsPdfServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/CellsPdfServiceTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Aspose.Cells;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Moq;
 using pdf_generator.Factories.Contracts;
 using pdf_generator.Services.PdfService;

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/DiagramPdfServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/DiagramPdfServiceTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Aspose.Diagram;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Moq;
 using pdf_generator.Factories.Contracts;
 using pdf_generator.Services.PdfService;

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/ImagingPdfServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/ImagingPdfServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Moq;
 using pdf_generator.Factories.Contracts;
 using pdf_generator.Services.PdfService;

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
@@ -68,7 +68,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOC, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOCX, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOCM, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.RTF, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.TXT, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.XLS, _documentId, _correlationId);
 
-            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.XLSX, _documentId, _correlationId);
 
-            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -124,7 +124,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.PPT, _documentId, _correlationId);
 
-            _mockSlidesPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockSlidesPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.PPTX, _documentId, _correlationId);
 
-            _mockSlidesPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockSlidesPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.BMP, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.GIF, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.JPG, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.JPEG, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.TIF, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.TIFF, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.PNG, _documentId, _correlationId);
 
-            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockImagingPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.VSD, _documentId, _correlationId);
 
-            _mockDiagramPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockDiagramPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -204,7 +204,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTML, _documentId, _correlationId);
 
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -212,7 +212,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTM, _documentId, _correlationId);
 
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -220,7 +220,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.MSG, _documentId, _correlationId);
 
-            _mockEmailPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockEmailPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.PDF, _documentId, _correlationId);
 
-            _mockPdfRendererService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockPdfRendererService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -238,7 +238,7 @@ namespace pdf_generator.tests.Services.PdfService
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTE, _documentId, _correlationId);
 
             // Assert
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
+            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
         }
 
         [Fact]
@@ -246,7 +246,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOT, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -254,7 +254,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOTM, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -262,7 +262,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.DOTX, _documentId, _correlationId);
 
-            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.XLSM, _documentId, _correlationId);
 
-            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.XLT, _documentId, _correlationId);
 
-            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockCellsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -287,7 +287,7 @@ namespace pdf_generator.tests.Services.PdfService
             _mockEmailPdfService.Setup(service => service.ReadToPdfStream(_inputStream, It.IsAny<MemoryStream>(), It.IsAny<Guid>()))
                 .Throws(new Exception());
 
-            Assert.Throws<PdfConversionException>(() => _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.MSG, _documentId, _correlationId));
+            Assert.Throws<PdfConversionException>(() => _pdfOrchestratorService.ReadToPdfStream(It.IsAny<MemoryStream>(), FileType.MSG, _documentId, _correlationId));
         }
     }
 }

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/SlidesPdfServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/SlidesPdfServiceTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Aspose.Slides;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Moq;
 using pdf_generator.Factories.Contracts;
 using pdf_generator.Services.PdfService;

--- a/polaris-pipeline/pdf-generator/Factories/AsposeItemFactory.cs
+++ b/polaris-pipeline/pdf-generator/Factories/AsposeItemFactory.cs
@@ -5,10 +5,14 @@ using Aspose.Diagram;
 using Aspose.Email;
 using Aspose.Pdf;
 using Aspose.Slides;
+using Common.Logging;
 using Microsoft.Extensions.Logging;
 using pdf_generator.Factories.Contracts;
-using Common.Logging;
-using LoadFormat = Aspose.Words.LoadFormat;
+using Document = Aspose.Words.Document;
+using HtmlLoadOptions = Aspose.Pdf.HtmlLoadOptions;
+using Image = Aspose.Imaging.Image;
+using WordLoadFormat = Aspose.Words.LoadFormat;
+using WordLoadOptions = Aspose.Words.Loading.LoadOptions;
 
 namespace pdf_generator.Factories
 {
@@ -48,16 +52,16 @@ namespace pdf_generator.Factories
 			return result;
 		}
 
-		public Aspose.Words.Document CreateMhtmlDocument(Stream inputStream, Guid correlationId)
+		public Document CreateMhtmlDocument(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateMhtmlDocument), string.Empty);
 
-			var result = new Aspose.Words.Document(inputStream, new Aspose.Words.Loading.LoadOptions { LoadFormat = LoadFormat.Mhtml });
+			var result = new Document(inputStream, new WordLoadOptions { LoadFormat = WordLoadFormat.Mhtml });
 			_logger.LogMethodExit(correlationId, nameof(CreateMhtmlDocument), string.Empty);
 			return result;
 		}
 
-		public Document CreateHtmlDocument(Stream inputStream, Guid correlationId)
+		public Aspose.Pdf.Document CreateHtmlDocument(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateHtmlDocument), string.Empty);
 
@@ -65,7 +69,7 @@ namespace pdf_generator.Factories
 			// Aspose is splitting the HTML into sections with whitespace between them. 
 			// Only a single PDF page is rendered with these gaps present
 			// Looks like the definition of a "page" is not quite right, likely configured here
-            var options = new Aspose.Pdf.HtmlLoadOptions
+            var options = new HtmlLoadOptions
             {
                 IsRenderToSinglePage = false,
                 PageInfo =
@@ -75,17 +79,17 @@ namespace pdf_generator.Factories
                 PageLayoutOption = HtmlPageLayoutOption.None
             };
 
-            var document = new Document(inputStream, options);
+            var document = new Aspose.Pdf.Document(inputStream, options);
 
 			_logger.LogMethodExit(correlationId, nameof(CreateHtmlDocument), string.Empty);
 			return document;
 		}
 
-		public Aspose.Imaging.Image CreateImage(Stream inputStream, Guid correlationId)
+		public Image CreateImage(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateImage), string.Empty);
 
-			var result = Aspose.Imaging.Image.Load(inputStream);
+			var result = Image.Load(inputStream);
 			_logger.LogMethodExit(correlationId, nameof(CreateImage), string.Empty);
 			return result;
 		}
@@ -99,16 +103,16 @@ namespace pdf_generator.Factories
 			return result;
 		}
 
-		public Aspose.Words.Document CreateWordsDocument(Stream inputStream, Guid correlationId)
+		public Document CreateWordsDocument(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateWordsDocument), string.Empty);
 
-			var result = new Aspose.Words.Document(inputStream);
+			var result = new Document(inputStream);
 			_logger.LogMethodExit(correlationId, nameof(CreateWordsDocument), string.Empty);
 			return result;
 		}
 
-		public Document CreateRenderedPdfDocument(Stream inputStream, Guid correlationId)
+		public Aspose.Pdf.Document CreateRenderedPdfDocument(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateRenderedPdfDocument), string.Empty);
 
@@ -117,7 +121,7 @@ namespace pdf_generator.Factories
 			return result;
 		}
 
-		public Document CreateRenderedXpsPdfDocument(Stream inputStream, Guid correlationId)
+		public Aspose.Pdf.Document CreateRenderedXpsPdfDocument(Stream inputStream, Guid correlationId)
 		{
 			_logger.LogMethodEntry(correlationId, nameof(CreateRenderedPdfDocument), string.Empty);
 

--- a/polaris-pipeline/pdf-generator/Factories/Contracts/IAsposeItemFactory.cs
+++ b/polaris-pipeline/pdf-generator/Factories/Contracts/IAsposeItemFactory.cs
@@ -5,6 +5,7 @@ using Aspose.Diagram;
 using Aspose.Email;
 using Aspose.Slides;
 using Aspose.Words;
+using Image = Aspose.Imaging.Image;
 
 namespace pdf_generator.Factories.Contracts
 {
@@ -20,7 +21,7 @@ namespace pdf_generator.Factories.Contracts
 
 		public Aspose.Pdf.Document CreateHtmlDocument(Stream inputStream, Guid correlationId);
 
-		public Aspose.Imaging.Image CreateImage(Stream inputStream, Guid correlationId);
+		public Image CreateImage(Stream inputStream, Guid correlationId);
 
 		public Presentation CreatePresentation(Stream inputStream, Guid correlationId);
 

--- a/polaris-pipeline/pdf-generator/Functions/TestConvertToPdf.cs
+++ b/polaris-pipeline/pdf-generator/Functions/TestConvertToPdf.cs
@@ -1,0 +1,74 @@
+﻿/*using System;
+using System.IO;
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.AspNetCore.Http;
+using pdf_generator.Services.PdfService;
+using Common.Domain.Exceptions;
+using Common.Extensions;
+using Common.Logging;
+
+namespace pdf_generator.Functions
+{
+    public class TestConvertToPdf
+    {
+        private readonly IPdfOrchestratorService _pdfOrchestratorService;
+        private readonly ILogger<TestConvertToPdf> _logger;
+        private const string LoggingName = nameof(TestConvertToPdf);
+
+        public TestConvertToPdf(
+             IPdfOrchestratorService pdfOrchestratorService,
+             ILogger<TestConvertToPdf> logger)
+        {
+            _pdfOrchestratorService = pdfOrchestratorService;
+            _logger = logger;
+        }
+
+        [Function(nameof(TestConvertToPdf))]
+        public IActionResult Run([HttpTrigger(AuthorizationLevel.Function, "post", Route = "test-convert-to-pdf")] HttpRequest request, 
+            FunctionContext executionContext)
+        {
+            var correlationId = Guid.NewGuid();
+            try
+            {
+                #region Validate-Inputs
+                
+                var fileType = request.Headers.GetFileType();
+                
+                const string documentId = "test-document";
+                
+                #endregion
+                
+                request.EnableBuffering();
+                if (request.ContentLength == null || !request.Body.CanSeek)
+                    throw new BadRequestException("An empty document stream was received from the TestClient", nameof(request));
+                
+                var originalBytes = request.ContentLength;
+                _logger.LogMethodFlow(correlationId, LoggingName, $"Original bytes received: {originalBytes}");
+                
+                request.Body.Seek(0, SeekOrigin.Begin);
+                    
+                var pdfStream = _pdfOrchestratorService.ReadToPdfStream(request.Body, fileType, documentId, Guid.NewGuid());
+                var bytes = pdfStream.Length;
+                _logger.LogMethodFlow(correlationId, LoggingName, $"Converted bytes: {bytes}");
+                    
+                pdfStream.Position = 0;
+                return new FileStreamResult(pdfStream, "application/pdf")
+                {
+                    FileDownloadName = $"{nameof(TestConvertToPdf)}.pdf",
+                };
+            }
+            catch (Exception exception)
+            {
+                _logger.LogMethodError(correlationId, LoggingName, exception.Message, exception);
+ 
+                return new ObjectResult(exception.ToString())
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError
+                };
+            }
+        }
+    }
+}*/

--- a/polaris-pipeline/pdf-generator/Services/PdfService/EmailPdfService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/EmailPdfService.cs
@@ -18,12 +18,12 @@ namespace pdf_generator.Services.PdfService
         public void ReadToPdfStream(Stream inputStream, Stream pdfStream, Guid correlationId)
         {
             var mailMsg = _asposeItemFactory.CreateMailMessage(inputStream, correlationId);
-            using var memoryStream = new MemoryStream();
+            var memoryStream = new MemoryStream();
             memoryStream.Seek(0, SeekOrigin.Begin);
             mailMsg.Save(memoryStream, SaveOptions.DefaultMhtml);
 
             //// load the MTHML from memoryStream into a document
-            var document = _asposeItemFactory.CreateMhtmlDocument(inputStream, correlationId);
+            var document = _asposeItemFactory.CreateMhtmlDocument(memoryStream, correlationId);
             document.Save(pdfStream, SaveFormat.Pdf);
             pdfStream.Seek(0, SeekOrigin.Begin);
         }

--- a/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
@@ -55,6 +55,9 @@ namespace pdf_generator.Services.PdfService
             try
             {
                 _logger.LogMethodFlow(correlationId, nameof(ReadToPdfStream), "Analysing file type and matching to a converter");
+                var serviceInputStream = new MemoryStream();
+                inputStream.CopyTo(serviceInputStream);
+                serviceInputStream.Seek(0, SeekOrigin.Begin);
                 var pdfStream = new MemoryStream();
                 switch (fileType)
                 {
@@ -66,7 +69,7 @@ namespace pdf_generator.Services.PdfService
                     case FileType.DOTX:
                     case FileType.RTF:
                     case FileType.TXT:
-                        _wordsPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _wordsPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.CSV:
@@ -74,12 +77,12 @@ namespace pdf_generator.Services.PdfService
                     case FileType.XLSX:
                     case FileType.XLSM:
                     case FileType.XLT:
-                        _cellsPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _cellsPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.PPT:
                     case FileType.PPTX:
-                        _slidesPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _slidesPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.BMP:
@@ -90,35 +93,35 @@ namespace pdf_generator.Services.PdfService
                     case FileType.TIF:
                     case FileType.TIFF:
                     case FileType.PNG:
-                        _imagingPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _imagingPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.VSD:
-                        _diagramPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _diagramPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.HTML:
                     case FileType.HTM:
-                        _htmlPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _htmlPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     // CMS HTE format is a custom HTML format, with a pre-<HTML> set of <b> tag metadata headers (i.e. not standard HTML)
                     // But Aspose seems forgiving enough to convert it, so treat it as HTML
                     case FileType.HTE:
-                        _htmlPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _htmlPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.EML:
                     case FileType.MSG:
-                        _emailPdfService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _emailPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.PDF:
-                        _pdfRendererService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _pdfRendererService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     case FileType.XPS:
-                        _xpsPdfRendererService.ReadToPdfStream(inputStream, pdfStream, correlationId);
+                        _xpsPdfRendererService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     default:


### PR DESCRIPTION
Fix bug where incoming input stream is handled different under aspnetcore than in-proc function operation. Added facility to copy the received stream to a memory stream before handing it over to Aspose. The Aspose libraries dispose the incoming stream. Also tidied up some references and fixed the EmailPdfService, which was not using the mail message it had just created when generating the MHTML document for conversion.