### PR TITLE
Add storage blob delegator to the permission set for the pdf generator

### DIFF
--- a/polaris-terraform/pipeline-events-terraform/storage-account.tf
+++ b/polaris-terraform/pipeline-events-terraform/storage-account.tf
@@ -11,6 +11,12 @@ resource "azurerm_role_assignment" "ra_blob_delegator_coordinator" {
   principal_id         = data.azurerm_linux_function_app.fa_coordinator.identity[0].principal_id
 }
 
+resource "azurerm_role_assignment" "ra_blob_delegator_pdf_generator" {
+  scope                = data.azurerm_storage_account.pipeline_storage_account.id
+  role_definition_name = "Storage Blob Delegator"
+  principal_id         = data.azurerm_windows_function_app.fa_pdf_generator.identity[0].principal_id
+}
+
 resource "azurerm_role_assignment" "ra_blob_data_contributor_pdf_generator" {
   scope                = data.azurerm_storage_container.pipeline_storage_container.resource_manager_id
   role_definition_name = "Storage Blob Data Contributor"


### PR DESCRIPTION
Add storage blob delegator to the permission set for the pdf generator - seems to need it under .NET 8