### PR TITLE
Fix for slow and inefficient .HTE conversion

### DIFF
--- a/polaris-pipeline/Common/Domain/Document/FileType.cs
+++ b/polaris-pipeline/Common/Domain/Document/FileType.cs
@@ -32,6 +32,8 @@
         DOTX,
         EMZ,
         EML,
-        XLT
+        XLT,
+        MHT,
+        MHTML
     }
 }

--- a/polaris-pipeline/pdf-generator.test-harness/Program.cs
+++ b/polaris-pipeline/pdf-generator.test-harness/Program.cs
@@ -1,173 +1,254 @@
 ﻿using Common.Constants;
 using Common.Domain.Document;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Common.Dto.Request;
 using Common.Dto.Request.Redaction;
 using Common.Factories;
 using Common.Factories.Contracts;
-using Common.Telemetry.Contracts;
 using Common.Telemetry;
+using Common.Telemetry.Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using pdf_generator.Services.DocumentRedaction;
 using pdf_generator.Services.Extensions;
 using pdf_generator.Services.PdfService;
-using pdf_generator.test_harness;
 using AppInsights = Microsoft.ApplicationInsights;
 
-var builder = Host.CreateApplicationBuilder(args);
+namespace pdf_generator.test_harness;
 
-SetAsposeLicence();
-
-builder.Configuration.AddEnvironmentVariables();
-builder.Configuration.SetBasePath(Directory.GetCurrentDirectory());
-builder.Configuration.AddJsonFile("local.settings.json", optional: false, reloadOnChange: true);
-
-//builder.Services.AddLogging(logging => logging.AddConsole());
-builder.Services.AddSingleton<AppInsights.TelemetryClient>();
-builder.Services.AddSingleton<ITelemetryClient, TelemetryClient>();
-
-builder.Services.AddPdfGenerator(builder.Configuration);
-builder.Services.AddRedactionServices(builder.Configuration);
-builder.Services.AddHttpClient(
-  "testClient",
-  client =>
-  {
-    client.BaseAddress = new Uri("http://localhost:7073/api/");
-  });
-builder.Services.AddTransient<IPipelineClientRequestFactory, PipelineClientRequestFactory>();
-using var host = builder.Build();
-
-var mode = args[0];
-
-Enum.TryParse(mode, out Mode modeEnum);
-using var serviceScope = host.Services.CreateScope();
-switch (modeEnum)
+internal static class Program
 {
-  case Mode.LibraryCallRedactPdf:
-    RedactPdfFile(serviceScope.ServiceProvider);
-    break;
-  case Mode.LibraryCallConvertToPdf:
-    ConvertFileToPdf(serviceScope.ServiceProvider);
-    break;
-  case Mode.FunctionCallConvertToPdf:
-    //await ConvertFileToPdfUsingFunctionCall(serviceScope.ServiceProvider);
-    break;
-  default:
-    throw new Exception("Unknown mode");
-}
-
-static void SetAsposeLicence()
-{
-  try
+  public static async Task Main(string[] args)
   {
-    const string licenceFileName = "Aspose.Total.NET.lic";
-    new Aspose.Cells.License().SetLicense(licenceFileName);
-    new Aspose.Diagram.License().SetLicense(licenceFileName);
-    new Aspose.Email.License().SetLicense(licenceFileName);
-    new Aspose.Imaging.License().SetLicense(licenceFileName);
-    new Aspose.Pdf.License().SetLicense(licenceFileName);
-    new Aspose.Slides.License().SetLicense(licenceFileName);
-    new Aspose.Words.License().SetLicense(licenceFileName);
-  }
-  catch (Exception exception)
-  {
-    throw new Exception(exception.Message);
-  }
-}
+    var builder = Host.CreateApplicationBuilder(args);
 
-static void RedactPdfFile(IServiceProvider serviceProvider)
-{
-  var redactionService = serviceProvider.GetRequiredService<IRedactionProvider>();
+    SetAsposeLicence();
 
-  Console.WriteLine("Enter the input file path:");
-  string? filePath = Console.ReadLine();
-  Console.WriteLine("Enter the output file path:");
-  string? outputFilePath = Console.ReadLine() ?? throw new Exception("Output file path is required");
+    builder.Configuration.AddEnvironmentVariables();
+    builder.Configuration.SetBasePath(Directory.GetCurrentDirectory());
+    builder.Configuration.AddJsonFile("local.settings.json", optional: false, reloadOnChange: true);
 
-  Console.WriteLine("Enter the number of pages to redact:");
-  if (!int.TryParse(Console.ReadLine(), out int numberOfPagesToRedact) || numberOfPagesToRedact <= 0)
-  {
-    Console.WriteLine("Invalid input for the number of pages. Exiting.");
-    return;
-  }
+    builder.Services.AddSingleton<AppInsights.TelemetryClient>();
+    builder.Services.AddSingleton<ITelemetryClient, TelemetryClient>();
 
-
-  if (File.Exists(filePath))
-  {
-    try
-    {
-      using var fileStream = File.OpenRead(filePath);
-
-      Guid currentCorrelationId = default;
-      var extension = Path.GetExtension(filePath).Replace(".", string.Empty).ToUpperInvariant();
-
-      var fileType = Enum.Parse<FileType>(extension);
-
-      var redactionDefinitions = new List<RedactionDefinitionDto>();
-      for (int pageIndex = 1; pageIndex <= numberOfPagesToRedact; pageIndex++)
+    builder.Services.AddPdfGenerator(builder.Configuration);
+    builder.Services.AddRedactionServices(builder.Configuration);
+    builder.Services.AddHttpClient(
+      "testClient",
+      client =>
       {
-        redactionDefinitions.Add(new RedactionDefinitionDto
+        client.BaseAddress = new Uri("http://localhost:7073/api/");
+      });
+    builder.Services.AddTransient<IPipelineClientRequestFactory, PipelineClientRequestFactory>();
+    using var host = builder.Build();
+
+    var mode = args[0];
+
+    if (!Enum.TryParse(mode, out Mode modeEnum))
+      throw new Exception("Unknown mode");
+      
+    using var serviceScope = host.Services.CreateScope();
+    switch (modeEnum)
+    {
+      case Mode.LibraryCallRedactPdf:
+        RedactPdfFile(serviceScope.ServiceProvider);
+        break;
+      case Mode.LibraryCallConvertToPdf:
+        ConvertFileToPdf(serviceScope.ServiceProvider);
+        break;
+      case Mode.FunctionCallConvertToPdf:
+        await ConvertFileToPdfUsingFunctionCall(serviceScope.ServiceProvider);
+        break;
+      default:
+        throw new Exception("Unknown mode");
+    }
+
+    return;
+
+    static void SetAsposeLicence()
+    {
+      try
+      {
+        const string licenceFileName = "Aspose.Total.NET.lic";
+        new Aspose.Cells.License().SetLicense(licenceFileName);
+        new Aspose.Diagram.License().SetLicense(licenceFileName);
+        new Aspose.Email.License().SetLicense(licenceFileName);
+        new Aspose.Imaging.License().SetLicense(licenceFileName);
+        new Aspose.Pdf.License().SetLicense(licenceFileName);
+        new Aspose.Slides.License().SetLicense(licenceFileName);
+        new Aspose.Words.License().SetLicense(licenceFileName);
+      }
+      catch (Exception exception)
+      {
+        throw new Exception(exception.Message);
+      }
+    }
+
+    static void RedactPdfFile(IServiceProvider serviceProvider)
+    {
+      var redactionService = serviceProvider.GetRequiredService<IRedactionProvider>();
+
+      Console.WriteLine("Enter the input file path:");
+      var filePath = Console.ReadLine();
+      Console.WriteLine("Enter the output file path:");
+      var outputFilePath = Console.ReadLine() ?? throw new Exception("Output file path is required");
+
+      Console.WriteLine("Enter the number of pages to redact:");
+      if (!int.TryParse(Console.ReadLine(), out int numberOfPagesToRedact) || numberOfPagesToRedact <= 0)
+      {
+        Console.WriteLine("Invalid input for the number of pages. Exiting.");
+        return;
+      }
+      
+      if (File.Exists(filePath))
+      {
+        try
         {
-          PageIndex = pageIndex,
-          Width = 842,
-          Height = 595,
-          RedactionCoordinates = new List<RedactionCoordinatesDto>
+          using var fileStream = File.OpenRead(filePath);
+
+          Guid currentCorrelationId = default;
+          var redactionDefinitions = new List<RedactionDefinitionDto>();
+          for (var pageIndex = 1; pageIndex <= numberOfPagesToRedact; pageIndex++)
+          {
+            redactionDefinitions.Add(new RedactionDefinitionDto
             {
+              PageIndex = pageIndex,
+              Width = 842,
+              Height = 595,
+              RedactionCoordinates =
+              [
                 new RedactionCoordinatesDto
                 {
-                    X1 = 228.5,
-                    Y1 = 241.5,
-                    X2 = 475.71,
-                    Y2 = 441.5
+                  X1 = 228.5,
+                  Y1 = 241.5,
+                  X2 = 475.71,
+                  Y2 = 441.5
                 }
-            }
-        });
+              ]
+            });
+          }
+
+          var redactPdf = new RedactPdfRequestDto
+          {
+            FileName = filePath,
+            CaseId = 1234,
+            VersionId = 1,
+            RedactionDefinitions = redactionDefinitions
+          };
+
+          var pdfStream = redactionService.Redact(fileStream, redactPdf, currentCorrelationId);
+
+          // Write the PDF stream to the file system
+          byte[] pdfBytes;
+          using (var ms = new MemoryStream())
+          {
+            pdfStream.CopyTo(ms);
+            pdfBytes = ms.ToArray();
+          }
+
+          File.WriteAllBytes(outputFilePath, pdfBytes);
+
+          Console.WriteLine("PDF conversion successful.");
+        }
+        catch (Exception e)
+        {
+          Console.WriteLine($"PDF conversion failed: {e.Message}");
+        }
       }
-
-      RedactPdfRequestDto redactPdf = new RedactPdfRequestDto
+      else
       {
-        FileName = filePath,
-        CaseId = 1234,
-        VersionId = 1,
-        RedactionDefinitions = redactionDefinitions
-      };
-
-      var pdfStream = redactionService.Redact(fileStream, redactPdf, currentCorrelationId);
-
-      // Write the PDF stream to the file system
-      byte[] pdfBytes;
-      using (MemoryStream ms = new MemoryStream())
-      {
-        pdfStream.CopyTo(ms);
-        pdfBytes = ms.ToArray();
+        throw new Exception("File does not exist, check path");
       }
-
-      File.WriteAllBytes(outputFilePath, pdfBytes);
-
-      Console.WriteLine("PDF conversion successful.");
     }
-    catch (Exception e)
+
+    static void ConvertFileToPdf(IServiceProvider serviceProvider)
     {
-      Console.WriteLine($"PDF conversion failed: {e.Message}");
+      var orchestratorService = serviceProvider.GetRequiredService<IPdfOrchestratorService>();
+
+      Console.WriteLine("Enter the input file path:");
+      var filePath = Console.ReadLine();
+      Console.WriteLine("Enter the output file path:");
+      var outputFilePath = Console.ReadLine() ?? throw new Exception("Output file path is required");
+
+      if (File.Exists(filePath))
+      {
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        PdfManager.BeginConversion(filePath, orchestratorService, outputFilePath);
+        watch.Stop();
+        Console.WriteLine($"Conversion time: {watch.ElapsedMilliseconds} ms");
+      }
+      else
+      {
+        throw new Exception("File does not exist, check path");
+      }
     }
-  }
-  else
-  {
-    throw new Exception("File does not exist, check path");
+    
+    static async Task ConvertFileToPdfUsingFunctionCall(IServiceProvider serviceProvider)
+    {
+      var pipelineClientRequestFactory = serviceProvider.GetRequiredService<IPipelineClientRequestFactory>();
+      var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+      
+      Console.WriteLine("Enter the input file path:");
+      var filePath = Console.ReadLine();
+      Console.WriteLine("Enter the output file path:");
+      var outputFilePath = Console.ReadLine() ?? throw new Exception("Output file path is required");
+
+      if (File.Exists(filePath))
+      {
+        try
+        {
+          await using var fileStream = File.OpenRead(filePath);
+
+          Guid currentCorrelationId = default;
+          var extension = Path.GetExtension(filePath).Replace(".", string.Empty).ToUpperInvariant();
+
+          var fileType = Enum.Parse<FileType>(extension);
+          
+          var request = pipelineClientRequestFactory.Create(HttpMethod.Post, $"test-convert-to-pdf", currentCorrelationId);
+          request.Headers.Add(HttpHeaderKeys.Filetype, fileType.ToString());
+
+          using (var requestContent = new StreamContent(fileStream))
+          {
+            request.Content = requestContent;
+
+            using var client = httpClientFactory.CreateClient("testClient");
+            using var pdfStream = new MemoryStream();
+            using (var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
+            {
+              response.EnsureSuccessStatusCode();
+              await response.Content.CopyToAsync(pdfStream);
+              pdfStream.Seek(0, SeekOrigin.Begin);
+            }
+            
+            // Write the PDF stream to the file system
+            byte[] pdfBytes;
+            using (var ms = new MemoryStream())
+            {
+              await pdfStream.CopyToAsync(ms);
+              pdfBytes = ms.ToArray();
+            }
+
+            await File.WriteAllBytesAsync(outputFilePath, pdfBytes);
+          }
+
+          Console.WriteLine("PDF conversion successful.");
+        }
+        catch (Exception e)
+        {
+          Console.WriteLine($"PDF conversion failed: {e.Message}");
+        }
+      }
+      else
+      {
+        throw new Exception("File does not exist, check path");
+      }
+    }
   }
 }
 
-static void ConvertFileToPdf(IServiceProvider serviceProvider)
+internal static class PdfManager
 {
-  var orchestratorService = serviceProvider.GetRequiredService<IPdfOrchestratorService>();
-
-  Console.WriteLine("Enter the input file path:");
-  string? filePath = Console.ReadLine();
-  Console.WriteLine("Enter the output file path:");
-  string? outputFilePath = Console.ReadLine() ?? throw new Exception("Output file path is required");
-
-  if (File.Exists(filePath))
+  internal static void BeginConversion(string filePath, IPdfOrchestratorService orchestratorService, string outputFilePath)
   {
     try
     {
@@ -175,7 +256,7 @@ static void ConvertFileToPdf(IServiceProvider serviceProvider)
 
       Guid currentCorrelationId = default;
       var extension = Path.GetExtension(filePath).Replace(".", string.Empty).ToUpperInvariant();
-      var documentId = "test-doc-1";
+      const string documentId = "test-doc-1";
 
       var fileType = Enum.Parse<FileType>(extension);
 
@@ -197,9 +278,5 @@ static void ConvertFileToPdf(IServiceProvider serviceProvider)
     {
       Console.WriteLine($"PDF conversion failed: {e.Message}");
     }
-  }
-  else
-  {
-    throw new Exception("File does not exist, check path");
   }
 }

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
@@ -204,7 +204,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTML, _documentId, _correlationId);
 
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -212,7 +212,7 @@ namespace pdf_generator.tests.Services.PdfService
         {
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTM, _documentId, _correlationId);
 
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()));
         }
 
         [Fact]
@@ -232,10 +232,30 @@ namespace pdf_generator.tests.Services.PdfService
         }
 
         [Fact]
-        public void ReadToPdfStream_CallsPdfRendererServiceWhenFileTypeIsHte()
+        public void ReadToPdfStream_CallsWordsServiceWhenFileTypeIsHte()
         {
             // Act
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTE, _documentId, _correlationId);
+
+            // Assert
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
+        }
+        
+        [Fact]
+        public void ReadToPdfStream_CallsWordsServiceWhenFileTypeIsMht()
+        {
+            // Act
+            _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.MHT, _documentId, _correlationId);
+
+            // Assert
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
+        }
+        
+        [Fact]
+        public void ReadToPdfStream_CallsWordsServiceWhenFileTypeIsMhtml()
+        {
+            // Act
+            _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.MHTML, _documentId, _correlationId);
 
             // Assert
             _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);

--- a/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
+++ b/polaris-pipeline/pdf-generator.tests/Services/PdfService/PdfOrchestratorServiceTests.cs
@@ -238,7 +238,7 @@ namespace pdf_generator.tests.Services.PdfService
             _pdfOrchestratorService.ReadToPdfStream(_inputStream, FileType.HTE, _documentId, _correlationId);
 
             // Assert
-            _mockHtmlPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
+            _mockWordsPdfService.Verify(service => service.ReadToPdfStream(It.IsAny<MemoryStream>(), It.IsAny<MemoryStream>(), It.IsAny<Guid>()), Times.Once);
         }
 
         [Fact]

--- a/polaris-pipeline/pdf-generator/Factories/AsposeItemFactory.cs
+++ b/polaris-pipeline/pdf-generator/Factories/AsposeItemFactory.cs
@@ -16,21 +16,15 @@ namespace pdf_generator.Factories
 {
 	public class AsposeItemFactory : IAsposeItemFactory
 	{
-		public AsposeItemFactory()
-		{
-		}
+		public Workbook CreateWorkbook(Stream inputStream, Guid correlationId) => new(inputStream);
 
-		public Workbook CreateWorkbook(Stream inputStream, Guid correlationId) =>
-			new Workbook(inputStream);
-
-		public Diagram CreateDiagram(Stream inputStream, Guid correlationId) =>
-			new Diagram(inputStream);
+		public Diagram CreateDiagram(Stream inputStream, Guid correlationId) => new(inputStream);
 
 		public MailMessage CreateMailMessage(Stream inputStream, Guid correlationId) =>
 			MailMessage.Load(inputStream);
 
 		public Document CreateMhtmlDocument(Stream inputStream, Guid correlationId) =>
-			new Document(inputStream, new WordLoadOptions { LoadFormat = WordLoadFormat.Mhtml });
+			new(inputStream, new WordLoadOptions {LoadFormat = WordLoadFormat.Mhtml});
 
 		public Aspose.Pdf.Document CreateHtmlDocument(Stream inputStream, Guid correlationId)
 		{
@@ -45,7 +39,8 @@ namespace pdf_generator.Factories
 				{
 					IsLandscape = false
 				},
-				PageLayoutOption = HtmlPageLayoutOption.None
+				PageLayoutOption = HtmlPageLayoutOption.None,
+				IsEmbedFonts = false
 			};
 
 			return new Aspose.Pdf.Document(inputStream, options);
@@ -54,16 +49,16 @@ namespace pdf_generator.Factories
 		public Image CreateImage(Stream inputStream, Guid correlationId) =>
 			Image.Load(inputStream);
 
-		public Presentation CreatePresentation(Stream inputStream, Guid correlationId) =>
-			new Presentation(inputStream);
+		public Presentation CreatePresentation(Stream inputStream, Guid correlationId) => new(inputStream);
 
-		public Document CreateWordsDocument(Stream inputStream, Guid correlationId) =>
-			new Document(inputStream);
+		public Document CreateWordsDocument(Stream inputStream, Guid correlationId) => new(inputStream);
 
-		public Aspose.Pdf.Document CreateRenderedPdfDocument(Stream inputStream, Guid correlationId) =>
-			new Aspose.Pdf.Document(inputStream);
+		public Aspose.Pdf.Document CreateRenderedPdfDocument(Stream inputStream, Guid correlationId)
+		{
+			return new Aspose.Pdf.Document(inputStream);
+		}
 
 		public Aspose.Pdf.Document CreateRenderedXpsPdfDocument(Stream inputStream, Guid correlationId) =>
-			new Aspose.Pdf.Document(inputStream, new XpsLoadOptions());
+			new(inputStream, new XpsLoadOptions());
 	}
 }

--- a/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
@@ -108,7 +108,7 @@ namespace pdf_generator.Services.PdfService
                     // CMS HTE format is a custom HTML format, with a pre-<HTML> set of <b> tag metadata headers (i.e. not standard HTML)
                     // But Aspose seems forgiving enough to convert it, so treat it as HTML
                     case FileType.HTE:
-                        _htmlPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
+                        _wordsPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId); //send to Word converter and the Word HTML renderer instead, much faster (33 -> 50% faster, reduces file size by up to 78% with no loss in quality)
                         break;
 
                     case FileType.EML:

--- a/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
+++ b/polaris-pipeline/pdf-generator/Services/PdfService/PdfOrchestratorService.cs
@@ -102,7 +102,9 @@ namespace pdf_generator.Services.PdfService
 
                     case FileType.HTML:
                     case FileType.HTM:
-                        _htmlPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
+                    case FileType.MHT:
+                    case FileType.MHTML:
+                        _wordsPdfService.ReadToPdfStream(serviceInputStream, pdfStream, correlationId);
                         break;
 
                     // CMS HTE format is a custom HTML format, with a pre-<HTML> set of <b> tag metadata headers (i.e. not standard HTML)


### PR DESCRIPTION
Following local tests, opted to redirect .HTE conversions to the Aspose.Words library and the Word HTML renderer. This seems to be massively faster and produces a much smaller file size with no perceivable loss of quality. 33->50% faster and up to 78% smaller file size, which will be of benefit further down the pipeline when OCR'ing

Also ended up testing general HTML conversion and realised that this is also superior via the Aspose.Words library instead of the Aspose.PDF version. Added support for .MHT and .MHTML file types to address a separate bug.