### PR TITLE
Story-24779: Added fallback ui cypress test, when the redaction logger is down

### DIFF
--- a/polaris-ui/cypress/e2e/case-details/redactionLog.cy.ts
+++ b/polaris-ui/cypress/e2e/case-details/redactionLog.cy.ts
@@ -2,6 +2,7 @@ import {
   SAVE_REDACTION_ROUTE,
   SAVE_REDACTION_LOG_ROUTE,
   REDACTION_LOG_MAPPING_ROUTE,
+  REDACTION_LOG_LOOKUP_ROUTE,
 } from "../../../src/mock-api/routes";
 import {
   expectedUnderRedactionType1Payload,
@@ -303,7 +304,29 @@ describe("Redaction Log", () => {
           "The entries into the Redaction Log have failed. Please go to the Redaction Log and enter manually. Don't worry the redacted document has saved into CMS successfully."
         );
     });
-
+    it("Should fallback and handle redaction without any redaction log if the redaction logger is down", () => {
+      cy.overrideRoute(
+        REDACTION_LOG_LOOKUP_ROUTE,
+        {
+          type: "break",
+          httpStatusCode: 500,
+          timeMs: 500,
+        },
+        "get",
+        Cypress.env("REACT_APP_REDACTION_LOG_BASE_URL")
+      );
+      cy.visit("/case-details/12AB1111111/13401?redactionLog=true");
+      cy.findByTestId("btn-accordion-open-close-all").click();
+      cy.findByTestId("link-document-1").click();
+      cy.findByTestId("div-pdfviewer-0")
+        .should("exist")
+        .contains("REPORT TO CROWN PROSECUTOR FOR CHARGING DECISION,");
+      cy.selectPDFTextElement("WEST YORKSHIRE POLICE");
+      cy.findByTestId("select-redaction-type").should("not.exist");
+      cy.findByTestId("btn-redact").click();
+      cy.findByTestId("btn-save-redaction-0").click();
+      cy.findByTestId("div-modal").should("not.exist");
+    });
     it("Should verify the save redaction log request data for under-redaction", () => {
       const saveRequestObject = { body: "" };
       cy.trackRequestBody(saveRequestObject, "POST", "/api/redactionLogs");
@@ -573,7 +596,6 @@ describe("Redaction Log", () => {
       cy.findByTestId("btn-save-redaction-log").click();
       cy.findByTestId("div-modal").should("not.exist");
     });
-
     it("Under Over redaction modal should throw error for empty  checkboxes values and should be able to successfully save an over redaction log", () => {
       cy.visit("/case-details/12AB1111111/13401?redactionLog=true");
       cy.findByTestId("btn-accordion-open-close-all").click();
@@ -772,6 +794,29 @@ describe("Redaction Log", () => {
         .contains(
           "The entries into the Redaction Log have failed. Please try again in the Casework App, or go to the Redaction Log app and enter manually."
         );
+    });
+    it(`Should fallback and should not show the "Log an Under/Over redaction" option in the Document actions, if the redaction logger is down`, () => {
+      cy.overrideRoute(
+        REDACTION_LOG_LOOKUP_ROUTE,
+        {
+          type: "break",
+          httpStatusCode: 500,
+          timeMs: 500,
+        },
+        "get",
+        Cypress.env("REACT_APP_REDACTION_LOG_BASE_URL")
+      );
+      cy.visit("/case-details/12AB1111111/13401?redactionLog=true");
+      cy.findByTestId("btn-accordion-open-close-all").click();
+      cy.findByTestId("link-document-1").click();
+      cy.findByTestId("div-pdfviewer-0")
+        .should("exist")
+        .contains("REPORT TO CROWN PROSECUTOR FOR CHARGING DECISION,");
+
+      cy.findByTestId("document-actions-dropdown-0").click();
+      cy.findByTestId("dropdown-panel")
+        .contains("Log an Under/Over redaction")
+        .should("not.exist");
     });
   });
 

--- a/polaris-ui/src/app/features/cases/presentation/case-details/index.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/index.tsx
@@ -361,9 +361,8 @@ export const Page: React.FC<Props> = ({ backLinkProps }) => {
                   correlationId: pipelineState?.correlationId,
                 }}
                 showOverRedactionLog={
-                  featureFlags.status === "succeeded"
-                    ? featureFlags.data.redactionLog &&
-                      FEATURE_FLAG_REDACTION_LOG_UNDER_OVER
+                  redactionLog.redactionLogLookUpsData.status === "succeeded"
+                    ? FEATURE_FLAG_REDACTION_LOG_UNDER_OVER
                     : false
                 }
               />

--- a/polaris-ui/src/mock-api/handlers.ts
+++ b/polaris-ui/src/mock-api/handlers.ts
@@ -141,7 +141,7 @@ export const setupHandlers = ({
     }),
 
     rest.get(
-      makeRedactionLogApiPath(routes.REDACTION_LOG_ROUTE),
+      makeRedactionLogApiPath(routes.REDACTION_LOG_LOOKUP_ROUTE),
       (req, res, ctx) => {
         const results = redactionLogDataSources[sourceName].lookUpsData;
         return res(delay(ctx), ctx.json(results));

--- a/polaris-ui/src/mock-api/routes.ts
+++ b/polaris-ui/src/mock-api/routes.ts
@@ -11,7 +11,7 @@ export const DOCUMENT_CHECKIN_ROUTE =
 export const SAVE_REDACTION_ROUTE =
   "api/urns/:urn/cases/:caseId/documents/:documentId";
 
-export const REDACTION_LOG_ROUTE = "/api/lookUps";
+export const REDACTION_LOG_LOOKUP_ROUTE = "/api/lookUps";
 export const REDACTION_LOG_MAPPING_ROUTE = "/api/polarisMappings";
 
 export const SAVE_REDACTION_LOG_ROUTE = "/api/redactionLogs";


### PR DESCRIPTION
https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/24779