### PR TITLE
#26128 Correct "git log" statement construction

### DIFF
--- a/polaris-devops-pipelines/deployments_v2/tasks/task_create-commit-report.yml
+++ b/polaris-devops-pipelines/deployments_v2/tasks/task_create-commit-report.yml
@@ -15,7 +15,9 @@ steps:
       script: |
         $targetLabel = "${{ parameters.targetLabel }}"
         $lowercaseTargetLabel = $targetLabel.ToLower()
-        git log $lowercaseTargetLabel...HEAD --oneline --pretty=format:%h,%an,%ae,%s > commit-report-$lowercaseTargetLabel.csv
+        $diffTag = "$lowercaseTargetLabel...HEAD"
+        $reportName = "commit-report-$lowercaseTargetLabel.csv"
+        git log "$diffTag" --oneline --pretty=format:%h,%an,%ae,%s > "$reportName"
     displayName: Generate commit report for ${{ parameters.targetLabel }}
 
   - task: PublishPipelineArtifact@1


### PR DESCRIPTION
#26128 Correct "git log" statement construction in task_create-commit-report.yml to allow for the insertion of dynamic parameters