### PR TITLE
Ensure escape chars are correctly handled

### DIFF
--- a/polaris-devops-pipelines/deployments_v2/tasks/task_update-app-keys-in-pipeline-components.yml
+++ b/polaris-devops-pipelines/deployments_v2/tasks/task_update-app-keys-in-pipeline-components.yml
@@ -42,11 +42,11 @@ steps:
       pdf_redactor_default_code=$(az functionapp keys list --resource-group rg-polaris-pipeline$ARM_SUFFIX --name fa-polaris$ARM_SUFFIX-pdf-redactor --query 'functionKeys.default' --output tsv)
       ddei_default_code=$(az functionapp keys list --resource-group rg-polaris-ddei$ARM_SUFFIX --name fa-polaris-ddei$ARM_SUFFIX --query 'functionKeys.default' --output tsv)
 
-      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings "PolarisPipelineCoordinatorDurableExtensionCode=$durable_code"
-      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings "PolarisPipelineTextExtractorFunctionAppKey=$text_extractor_default_code"
-      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings "PolarisPipelineRedactPdfFunctionAppKey=$pdf_generator_default_code"
-      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings "PolarisPipelineRedactorPdfFunctionAppKey=$pdf_generator_default_code"
-      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings "DdeiAccessKey=$ddei_default_code"
+      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings PolarisPipelineCoordinatorDurableExtensionCode="$durable_code"
+      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings PolarisPipelineTextExtractorFunctionAppKey="$text_extractor_default_code"
+      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings PolarisPipelineRedactPdfFunctionAppKey="$pdf_generator_default_code"
+      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings PolarisPipelineRedactorPdfFunctionAppKey="$pdf_generator_default_code"
+      az functionapp config appsettings set --name fa-polaris$ARM_SUFFIX-coordinator --resource-group rg-polaris-pipeline$ARM_SUFFIX --slot "staging1" --settings DdeiAccessKey="$ddei_default_code"
     displayName: Script > Update Keys in Pipeline Component Config
     env:
       ARM_CLIENT_ID: ${{ parameters.armClientId }}


### PR DESCRIPTION
Ensure escape chars are correctly handled when updating pipeline app component key references in the coordinator before a swap