### PR TITLE
#27727 - change proxy rules to acommodate any CMS version in the URL

### DIFF
--- a/polaris-terraform/ui-terraform/nginx.conf
+++ b/polaris-terraform/ui-terraform/nginx.conf
@@ -90,7 +90,7 @@ http {
     # CMS UI traffic
 
     # CMS menu bar JS - add task list link
-    location ~ /CMS\..*/Noexpiry/Toolbar/uainMenuBar.js {
+    location ~ ^/CMS\..*/Noexpiry/Toolbar/uainMenuBar.js {
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
       add_header 'x-limit-req-status' $limit_req_status always;
@@ -117,7 +117,7 @@ http {
       proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM};
     }
 
-    location ~ /CMS\..*/Case/uacdCDTabs.aspx {
+    location ~ ^/CMS\..*/Case/uacdCDTabs.aspx {
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
       add_header 'x-limit-req-status' $limit_req_status always;
@@ -146,7 +146,7 @@ http {
     # When regex rules are used, nginx stops processing rules when it finds the first rule that mathces a 
     #  route. So we put the most general route last, to avoid it taking precedence over the more specific 
     #  rules above.
-    location ~ /CMS\..* {
+    location ~ ^/CMS\..* {
       client_max_body_size 0; # until we find out what CMS's max upload size is
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};

--- a/polaris-terraform/ui-terraform/nginx.conf
+++ b/polaris-terraform/ui-terraform/nginx.conf
@@ -88,41 +88,9 @@ http {
     }
 
     # CMS UI traffic
-    location /CMS.20.0.04 {
-      client_max_body_size 0; # until we find out what CMS's max upload size is
-      access_log  /dev/stdout cms_log;
-      limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
-      add_header 'x-limit-req-status' $limit_req_status always;
-    
-      # IE Mode Desired
-      if ( $ieaction = 'nonie+nonconfigurable+') {
-        return 402 'requires Internet Explorer mode';
-      }
-      if ( $ieaction = 'nonie+configurable+') {
-        add_header X-InternetExplorerMode 1;
-        return 302 "${WEBSITE_SCHEME}://${host}${request_uri}";
-      }
-      sub_filter_types *;
-      sub_filter_once off;
-      sub_filter ${UPSTREAM_CMS_DOMAIN_NAME} $host;
-      sub_filter ${UPSTREAM_CMS_SERVICES_DOMAIN_NAME} $host;
-      sub_filter ${UPSTREAM_CMS_MODERN_DOMAIN_NAME} $host;
-      sub_filter https:// ${WEBSITE_SCHEME}://;
-  
-      proxy_redirect     off;
-      proxy_ssl_server_name on;
 
-      proxy_ssl_session_reuse off;
-      proxy_ssl_verify off;
-
-      proxy_set_header Host ${UPSTREAM_CMS_DOMAIN_NAME}:443;
-      proxy_set_header X-Forwarded-For $remote_addr;
-
-      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM};
-    }
-    
     # CMS menu bar JS - add task list link
-    location /CMS.20.0.04/Noexpiry/Toolbar/uainMenuBar.js {
+    location ~ /CMS\..*/Noexpiry/Toolbar/uainMenuBar.js {
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
       add_header 'x-limit-req-status' $limit_req_status always;
@@ -149,7 +117,7 @@ http {
       proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM};
     }
 
-    location /CMS.20.0.04/Case/uacdCDTabs.aspx {
+    location ~ /CMS\..*/Case/uacdCDTabs.aspx {
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
       add_header 'x-limit-req-status' $limit_req_status always;
@@ -163,6 +131,42 @@ http {
 
       sub_filter '</html>' '<script src="/polaris-script.js"></script></html>';
       
+      proxy_redirect     off;
+      proxy_ssl_server_name on;
+
+      proxy_ssl_session_reuse off;
+      proxy_ssl_verify off;
+
+      proxy_set_header Host ${UPSTREAM_CMS_DOMAIN_NAME}:443;
+      proxy_set_header X-Forwarded-For $remote_addr;
+
+      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM};
+    }
+
+    # When regex rules are used, nginx stops processing rules when it finds the first rule that mathces a 
+    #  route. So we put the most general route last, to avoid it taking precedence over the more specific 
+    #  rules above.
+    location ~ /CMS\..* {
+      client_max_body_size 0; # until we find out what CMS's max upload size is
+      access_log  /dev/stdout cms_log;
+      limit_req zone=cmsproxy burst=${CMS_RATE_LIMIT_QUEUE};
+      add_header 'x-limit-req-status' $limit_req_status always;
+    
+      # IE Mode Desired
+      if ( $ieaction = 'nonie+nonconfigurable+') {
+        return 402 'requires Internet Explorer mode';
+      }
+      if ( $ieaction = 'nonie+configurable+') {
+        add_header X-InternetExplorerMode 1;
+        return 302 "${WEBSITE_SCHEME}://${host}${request_uri}";
+      }
+      sub_filter_types *;
+      sub_filter_once off;
+      sub_filter ${UPSTREAM_CMS_DOMAIN_NAME} $host;
+      sub_filter ${UPSTREAM_CMS_SERVICES_DOMAIN_NAME} $host;
+      sub_filter ${UPSTREAM_CMS_MODERN_DOMAIN_NAME} $host;
+      sub_filter https:// ${WEBSITE_SCHEME}://;
+      sub_filter '</html>' '<!-- General rule applied --></html>';
       proxy_redirect     off;
       proxy_ssl_server_name on;
 
@@ -329,7 +333,7 @@ http {
     }
 
     # internal-only route to CMS Classic, used by DDEI
-    location /internal-implementation/corsham/CMS.20.0.04/ {
+    location /internal-implementation/corsham/ {
       client_max_body_size 0; # until we find out what CMS's max upload size is
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsgateway burst=${CMS_RATE_LIMIT_QUEUE};
@@ -344,7 +348,7 @@ http {
       proxy_set_header Host ${UPSTREAM_CMS_DOMAIN_NAME}:443;
       proxy_set_header X-Forwarded-For $remote_addr;
 
-      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM}/CMS.20.0.04/;
+      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_CORSHAM}/;
     }
 
     # internal-only route to CMS Modern, used by DDEI
@@ -377,7 +381,7 @@ http {
     }
 
     # internal-only route to CMS Classic, used by DDEI
-    location /internal-implementation/farnborough/CMS.20.0.04/ {
+    location /internal-implementation/farnborough/ {
       client_max_body_size 0; # until we find out what CMS's max upload size is
       access_log  /dev/stdout cms_log;
       limit_req zone=cmsgateway burst=${CMS_RATE_LIMIT_QUEUE};
@@ -392,7 +396,7 @@ http {
       proxy_set_header Host ${UPSTREAM_CMS_DOMAIN_NAME}:443;
       proxy_set_header X-Forwarded-For $remote_addr;
 
-      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_FARNBOROUGH}/CMS.20.0.04/;
+      proxy_pass ${ENDPOINT_HTTP_PROTOCOL}://${UPSTREAM_CMS_IP_FARNBOROUGH}/;
     }
 
     # internal-only route to CMS Modern, used by DDEI


### PR DESCRIPTION
Lots of noise in the diff, but only three changes:

1) Go to regex in proxied-CMS routes e.g. location `~ /CMS\..*/Case/uacdCDTabs.aspx` . This lets any CMS version come through in the URL and to be forwarded to that version at the destination.

2) Now that regex rules exist, we have to move the general `location ~ ^/CMS\..*` beneath the two more specific rules dealing with CMS Classic routes.  When matching regex routes, nginx will stop at the first route which matches (unlike "fixed" routes where all routes are assessed and then the most specific match used)

3) Remove the CMS.XX.X.X element of the location from the `internal-implementation` routes.  This has the effect of allowing a "whatever version of CMS you are coming in with will get passed on" approach as per item 1.