### PR TITLE
Revert earlier exclusion of one of the outbound dns servers - all seems well now.

### DIFF
--- a/polaris-terraform/networking-terraform/dns-resolver.tf
+++ b/polaris-terraform/networking-terraform/dns-resolver.tf
@@ -68,11 +68,10 @@ resource "azurerm_private_dns_resolver_forwarding_rule" "polaris_dns_resolver_fo
   dns_forwarding_ruleset_id = azurerm_private_dns_resolver_dns_forwarding_ruleset.polaris_dns_resolver_forwarding_ruleset.id
   domain_name               = "cps.gov.uk."
   enabled                   = true
-  //not currently working - Jamie raising it with Michael
-  //target_dns_servers {
-  //  ip_address = "10.8.0.6"
-  //  port       = 53
-  //}
+  target_dns_servers {
+    ip_address = "10.8.0.6"
+    port       = 53
+  }
   target_dns_servers {
     ip_address = "10.8.0.7"
     port       = 53


### PR DESCRIPTION
Revert "Temporarily removed one of the outbound DNS servers while Jamie sorts it with Michael (#1362)"

This reverts commit d934a9e7cd556a7121caa1b8cb39e27f6ac53038.