### PR TITLE
BugFix:28212 :  Delete page request failing

### DIFF
--- a/polaris-ui/src/app/features/cases/presentation/case-details/pdf-tabs/PdfTab.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/pdf-tabs/PdfTab.tsx
@@ -283,7 +283,8 @@ export const PdfTab: React.FC<PdfTabProps> = ({
             documentType,
             saveStatus: saveStatus,
             caseId,
-            showDeletePage: contextData.showDeletePage,
+            showDeletePage:
+              contextData.showDeletePage && documentType !== "DAC",
           }}
           isOkToSave={isOkToSave}
           redactionHighlights={redactionHighlights}

--- a/polaris-ui/src/app/features/cases/presentation/case-details/portals/DeletePage.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/portals/DeletePage.tsx
@@ -57,6 +57,7 @@ export const DeletePage: React.FC<DeletePageProps> = ({
     setShowModal(true);
   };
   const handleConfirmRedaction = () => {
+    setShowModal(false);
     const redactionType = redactionTypesData.find(
       (type) => type.id === deleteRedactionType
     )!;
@@ -66,8 +67,6 @@ export const DeletePage: React.FC<DeletePageProps> = ({
       pageNumber: pageNumber,
       reason: redactionType.name,
     });
-
-    setShowModal(false);
   };
   const handleRedactionTypeSelection = (value: string) => {
     setDeleteRedactionType(value);


### PR DESCRIPTION
- https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/28212
- Also excluded DAC docs from page delete
- Cannot reproduce the issue, but looking at the appInsight, the user some how manage to add the 'Page Delete' confirmation twice. Hence we are putting a fix by blocking the chance of  adding any duplicate page delete entry  to the state  