### PR TITLE
Pass CMS cookie in both __cc and cc parameters 

### DIFF
--- a/polaris-terraform/main-terraform/nginx.js
+++ b/polaris-terraform/main-terraform/nginx.js
@@ -53,7 +53,7 @@ function appAuthRedirect(r) {
       r,
       `${redirectUrl}${
         redirectUrl.includes("?") ? "&" : "?"
-      }__cc=${encodeURIComponent(args["cookie"] ?? "")}`
+      }cc=${encodeURIComponent(args["cookie"] ?? "")}&__cc=${encodeURIComponent(args["cookie"] ?? "")}`
     )
   } else {
     r.return(


### PR DESCRIPTION
OutSystems doesn't support __cc as a parameter name.
Housekeeping app is using __cc.

This is a temporary modification until the parameter is standardised to something compatible with both platforms.