### PR TITLE
navigate-cms (wrapper) functionality to support proxied route to CMS

### DIFF
--- a/polaris-terraform/main-terraform/nginx.conf
+++ b/polaris-terraform/main-terraform/nginx.conf
@@ -125,7 +125,7 @@ http {
       # localStorage.  Once the iframe fires its onload event, we redirect back to Edge mode, only because it appears window.close works in Edge without prompting the user (in
       # IE mode it prompts the user for approval to close the tab).
       #
-      return 200 '<html><body><iframe src="https://$arg_domain/CMSModern/Navigation/Notification.html?$args" onload=\'window.location.href="/navigate-cms-close"\'></iframe></body></html>';
+      return 200 '<html><body><script type="text/javascript">var c = 0; function fl() { if(++c > 1) { window.location.href="/navigate-cms-close"; } }</script><iframe src="${WEBSITE_SCHEME}://${host}/CMSModern/Navigation/Notification.html?$args" onload="fl()"></iframe><iframe src="https://$arg_domain/CMSModern/Navigation/Notification.html?$args" onload="fl()"></iframe></body></html>';
     }
 
 		location = /navigate-cms-close {


### PR DESCRIPTION
Existing implementation pulled the CMS domain out the cookie and used this in the source of the IFRAME to wrap the CMS navigation component.

This didn't work for scenarios where the journey starts from proxied CMS.

This enhancement includes two IFRAMEs to wrap the navigation. One targeting the detected CMS domain from the cookie, and one targeting the proxied CMS domain.

This has been tested in QA.