### PR TITLE
Re-add the mistakenly removed initialization of the blob storage service factory

### DIFF
--- a/polaris-pipeline/pdf-thumbnail-generator/Program.cs
+++ b/polaris-pipeline/pdf-thumbnail-generator/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.DurableTask.Client;
 using pdf_thumbnail_generator.Durable.Providers;
 using Microsoft.Extensions.Configuration;
 using Common.Handlers;
+using Common.Services.BlobStorage;
 using Microsoft.Extensions.Logging;
 using pdf_thumbnail_generator;
 using Common.Telemetry;
@@ -38,6 +39,7 @@ var host = new HostBuilder()
         services.AddSingleton<ITelemetryClient, TelemetryClient>();
         services.AddTransient<IExceptionHandler, ExceptionHandler>();
         services.AddSingleton<IJsonConvertWrapper, JsonConvertWrapper>();
+        services.AddBlobStorageWithDefaultAzureCredential(context.Configuration);
     })
     .ConfigureLogging(logging =>
     {

--- a/polaris-terraform/main-terraform/app-service-proxy-staging.tf
+++ b/polaris-terraform/main-terraform/app-service-proxy-staging.tf
@@ -164,6 +164,10 @@ resource "azurerm_private_endpoint" "polaris_proxy_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_linux_web_app_slot.polaris_proxy_staging1
+  ]
 }
 
 resource "azurerm_monitor_diagnostic_setting" "proxy_staging1_diagnostic_settings" {

--- a/polaris-terraform/main-terraform/app-service-spa-staging.tf
+++ b/polaris-terraform/main-terraform/app-service-spa-staging.tf
@@ -141,4 +141,8 @@ resource "azurerm_private_endpoint" "polaris_ui_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_linux_web_app_slot.as_web_polaris_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-coordinator-staging.tf
+++ b/polaris-terraform/main-terraform/function-coordinator-staging.tf
@@ -114,4 +114,8 @@ resource "azurerm_private_endpoint" "pipeline_coordinator_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_linux_function_app_slot.fa_coordinator_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-gateway-staging.tf
+++ b/polaris-terraform/main-terraform/function-gateway-staging.tf
@@ -131,4 +131,8 @@ resource "azurerm_private_endpoint" "polaris_gateway_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_linux_function_app_slot.fa_polaris_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-pdf-generator-staging.tf
+++ b/polaris-terraform/main-terraform/function-pdf-generator-staging.tf
@@ -93,4 +93,8 @@ resource "azurerm_private_endpoint" "pipeline_pdf_generator_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_windows_function_app_slot.fa_pdf_generator_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-pdf-redactor-staging.tf
+++ b/polaris-terraform/main-terraform/function-pdf-redactor-staging.tf
@@ -93,4 +93,8 @@ resource "azurerm_private_endpoint" "pipeline_pdf_redactor_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_windows_function_app_slot.fa_pdf_redactor_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-pdf-thumbnail-generator-staging.tf
+++ b/polaris-terraform/main-terraform/function-pdf-thumbnail-generator-staging.tf
@@ -95,4 +95,8 @@ resource "azurerm_private_endpoint" "pipeline_pdf_thumbnail_generator_staging1_p
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_windows_function_app_slot.fa_pdf_thumbnail_generator_staging1
+  ]
 }

--- a/polaris-terraform/main-terraform/function-text-extractor-staging.tf
+++ b/polaris-terraform/main-terraform/function-text-extractor-staging.tf
@@ -89,4 +89,8 @@ resource "azurerm_private_endpoint" "pipeline_text_extractor_staging1_pe" {
     is_manual_connection           = false
     subresource_names              = ["sites-staging1"]
   }
+
+  depends_on = [
+    azurerm_linux_function_app_slot.fa_text_extractor_staging1
+  ]
 }


### PR DESCRIPTION
Re-add the mistakenly removed initialization of the blob storage service factory for the documents and thumbnails containers to the PDF Thumbnail Generator startup config