### PR TITLE
Removed branch details from sandbox alerting release pipeline

### DIFF
--- a/polaris-devops-pipelines/deployments_v2/alerting/alerting-release-uat.yml
+++ b/polaris-devops-pipelines/deployments_v2/alerting/alerting-release-uat.yml
@@ -6,12 +6,7 @@ resources:
   pipelines:
     - pipeline: PolarisAlertingBuild
       source: Polaris Alerting Build - UAT
-      trigger:
-        branches:
-          include:
-            - refs/heads/main
-        stages:
-          - Publish_Artifacts
+      trigger: true
             
 variables:
   - group: kv-uat-terraform


### PR DESCRIPTION
Removed branch details from sandbox alerting release pipeline so that it runs whenever a manual build is instigated against any branch