### PR TITLE
Bugfix/28421 cannot perform xmltransformations on non-windows machine

### DIFF
--- a/polaris-e2e/deploy-pipeline-by-branch.yml
+++ b/polaris-e2e/deploy-pipeline-by-branch.yml
@@ -1,8 +1,6 @@
 pr: none
 trigger: none
 
-pool:
-  name: $(build-agent)
 
 # schedules:
 #   # Switch off pre-midnight runs for now, devs still working/releasing
@@ -30,14 +28,16 @@ stages:
   - stage: Run_e2e_Tests
     displayName: Run e2e Tests
     jobs:
-      - job: Run_DotNet_Tests
-        displayName: Run DotNet Tests
+      - job: Prepare_DotNet_Tests
+        displayName: Prepare DotNet Tests
+        pool:
+          vmImage: 'windows-latest'
         steps:
-          - checkout: PolarisBranch
+          - checkout: PolarisTagged
             clean: true
             persistCredentials: true
             fetchDepth: 1
-            displayName: "Checkout polaris-e2e"
+            displayName: "Checkout polaris-e2e at $(cypress_environment) tag"
 
           - task: DownloadSecureFile@1
             name: licence
@@ -66,10 +66,26 @@ stages:
               targetFolder: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
             displayName: "Copy Aspose.Total.NET.lic"
 
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
+              artifact: "pdf-redactor-tests-drop"
+            displayName: "Publish PDF Redactor tests artifact"
+            
+      - job: Run_DotNet_Tests
+        displayName: Run DotNet Tests
+        dependsOn: Prepare_DotNet_Tests
+        pool:
+          name: $(build-agent)
+        steps:
+          - download: current
+            displayName: Download PDF Redactor Tests
+            artifact: "pdf-redactor-tests-drop"
+
           - task: PowerShell@2
             inputs:
               targetType: "inline"
-              workingDirectory: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
+              workingDirectory: "$(Pipeline.Workspace)/pdf-redactor-tests-drop"
               script: |
                 dotnet ./pdf-redactor.integration.tests.dll
               failOnStderr: true
@@ -77,6 +93,8 @@ stages:
 
       - job: Run_Cypress_Tests_A
         displayName: Run Cypress Tests A
+        pool:
+          name: $(build-agent)
         steps:
           - checkout: PolarisBranch
             clean: true
@@ -125,6 +143,8 @@ stages:
 
       - job: Run_Cypress_Tests_B
         displayName: Run Cypress Tests B
+        pool:
+          name: $(build-agent)
         steps:
           - checkout: PolarisBranch
             clean: true

--- a/polaris-e2e/deploy-pipeline.yml
+++ b/polaris-e2e/deploy-pipeline.yml
@@ -50,7 +50,7 @@ stages:
     displayName: Run e2e Tests
     jobs:
       - job: Prepare_DotNet_Tests
-        displayName: Run DotNet Tests
+        displayName: Prepare DotNet Tests
         pool:
           vmImage: 'windows-latest'
         steps:

--- a/polaris-e2e/deploy-pipeline.yml
+++ b/polaris-e2e/deploy-pipeline.yml
@@ -54,6 +54,8 @@ stages:
     jobs:
       - job: Run_DotNet_Tests
         displayName: Run DotNet Tests
+        pool:
+          vmImage: 'windows-latest'
         steps:
           - checkout: PolarisTagged
             clean: true

--- a/polaris-e2e/deploy-pipeline.yml
+++ b/polaris-e2e/deploy-pipeline.yml
@@ -87,16 +87,26 @@ stages:
               targetFolder: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
             displayName: "Copy Aspose.Total.NET.lic"
             
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
+              artifact: "pdf-redactor-tests-drop"
+            displayName: "Publish PDF Redactor tests artifact"
+            
       - job: Run_DotNet_Tests
         displayName: Run DotNet Tests
         dependsOn: Prepare_DotNet_Tests
         pool:
           name: $(build-agent)
         steps:
+          - download: current
+            displayName: Download PDF Redactor Tests
+            artifact: "pdf-redactor-tests-drop"
+            
           - task: PowerShell@2
             inputs:
               targetType: "inline"
-              workingDirectory: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
+              workingDirectory: "$(Pipeline.Workspace)/pdf-redactor-tests-drop"
               script: |
                 dotnet ./pdf-redactor.integration.tests.dll
               failOnStderr: true

--- a/polaris-e2e/deploy-pipeline.yml
+++ b/polaris-e2e/deploy-pipeline.yml
@@ -1,8 +1,5 @@
 trigger: none
 
-pool:
-  name: $(build-agent)
-
 schedules:
   # Switch off pre-midnight runs for now, devs still working/releasing
   #  and the e2e tests runs use up agents and otherwise confound releases
@@ -52,7 +49,7 @@ stages:
   - stage: Run_e2e_Tests
     displayName: Run e2e Tests
     jobs:
-      - job: Run_DotNet_Tests
+      - job: Prepare_DotNet_Tests
         displayName: Run DotNet Tests
         pool:
           vmImage: 'windows-latest'
@@ -89,7 +86,13 @@ stages:
               contents: Aspose.Total.NET.lic
               targetFolder: "$(System.DefaultWorkingDirectory)/polaris-pipeline/pdf-redactor.integration.tests/bin/Release/net8.0"
             displayName: "Copy Aspose.Total.NET.lic"
-
+            
+      - job: Run_DotNet_Tests
+        displayName: Run DotNet Tests
+        dependsOn: Prepare_DotNet_Tests
+        pool:
+          name: $(build-agent)
+        steps:
           - task: PowerShell@2
             inputs:
               targetType: "inline"
@@ -101,6 +104,8 @@ stages:
 
       - job: Run_Cypress_Tests_A
         displayName: Run Cypress Tests A
+        pool:
+          name: $(build-agent)
         steps:
           - checkout: PolarisTagged
             clean: true
@@ -150,6 +155,8 @@ stages:
 
       - job: Run_Cypress_Tests_B
         displayName: Run Cypress Tests B
+        pool:
+          name: $(build-agent)
         steps:
           - checkout: PolarisTagged
             clean: true


### PR DESCRIPTION
Strange reoccurrence of an issue that was previously fixed. The fix used to require setting the "xmlTransformationRules" property of the FileTransform@2 task to an empty string to prevent the XML parser in the underlying code from running while performing JSON transformations. This has stopped working and required this fix to separate the Redactor log testing job into two - one to prepare on a Windows MS-hosted agent and then copy as a pipeline artifact and introduce a second job to run on our self-hosted agents that copies the artifact down and runs the tests.