### PR TITLE
Chore/ensure legacy dotnet versions can be installed on agent

### DIFF
--- a/polaris-devops-pipelines/scale-set/build-agent.sh
+++ b/polaris-devops-pipelines/scale-set/build-agent.sh
@@ -1,7 +1,6 @@
 ﻿echo '==== Install dependencies ===='
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
-
 echo '==== Update package sources ===='
 sudo apt-get update
 

--- a/polaris-devops-pipelines/scale-set/build-agent.sh
+++ b/polaris-devops-pipelines/scale-set/build-agent.sh
@@ -1,10 +1,10 @@
 ﻿echo '==== Install dependencies ===='
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
-Invoke-WebRequest -Uri https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -OutFile ./packages-microsoft-prod.deb -UseBasicParsing ; `
 echo 'Register the Microsoft repository GPG keys'
-dpkg -i ./packages-microsoft-prod.deb ; `
-rm ./packages-microsoft-prod.deb
+wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo rm packages-microsoft-prod.deb
 
 echo '==== Update package sources ===='
 sudo apt-get update

--- a/polaris-devops-pipelines/scale-set/build-agent.sh
+++ b/polaris-devops-pipelines/scale-set/build-agent.sh
@@ -1,6 +1,11 @@
 ﻿echo '==== Install dependencies ===='
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
+Invoke-WebRequest -Uri https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -OutFile ./packages-microsoft-prod.deb -UseBasicParsing ; `
+echo 'Register the Microsoft repository GPG keys'
+dpkg -i ./packages-microsoft-prod.deb ; `
+rm ./packages-microsoft-prod.deb
+
 echo '==== Update package sources ===='
 sudo apt-get update
 

--- a/polaris-devops-pipelines/scale-set/build-agent.sh
+++ b/polaris-devops-pipelines/scale-set/build-agent.sh
@@ -1,19 +1,9 @@
 ﻿echo '==== Install dependencies ===='
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
-echo 'Register the Microsoft repository GPG keys'
-wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-sudo dpkg -i packages-microsoft-prod.deb
-sudo rm packages-microsoft-prod.deb
 
 echo '==== Update package sources ===='
 sudo apt-get update
-
-echo '==== dotnet 6 ===='
-sudo apt-get update -y && sudo apt-get install -y dotnet-sdk-6.0
-
-echo '==== dotnet 7 ===='
-sudo apt-get update -y && sudo apt-get install -y dotnet-sdk-7.0
 
 echo '==== dotnet 8 ===='
 sudo apt-get update -y && sudo apt-get install -y dotnet-sdk-8.0
@@ -106,3 +96,9 @@ sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/chrome-keyring.g
 sudo apt-get update -yq
 sudo apt-get install -y google-chrome-stable
 sudo apt-get clean
+
+wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+
+sudo chmod +x ./dotnet-install.sh
+./dotnet-install.sh --channel 6.0 --quality GA
+./dotnet-install.sh --channel 7.0 --quality GA


### PR DESCRIPTION
Use dotnet install script as the latest ubuntu package source no longer contain version 6 or 7 as they are no longer supported.