### PR TITLE
BugFix: 28663 - Fixed the Search result count

### DIFF
--- a/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.test.ts
+++ b/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.test.ts
@@ -12,6 +12,12 @@ describe("mapTextSearch", () => {
         words: [
           { boundingBox: [1], text: "foo", confidence: 1, matchType: "Exact" },
           { boundingBox: null, text: "bar", confidence: 1, matchType: "None" },
+          {
+            boundingBox: null,
+            text: "test",
+            confidence: 1,
+            matchType: "Exact",
+          },
         ],
       },
       {
@@ -65,6 +71,10 @@ describe("mapTextSearch", () => {
                 {
                   isHighlighted: false,
                   text: "bar",
+                },
+                {
+                  isHighlighted: false,
+                  text: "test",
                 },
               ],
               id: "1",

--- a/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.ts
+++ b/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.ts
@@ -37,7 +37,7 @@ export const mapTextSearch = (
       const { id, pageIndex, words, pageHeight, pageWidth } = apiResultDocument;
 
       const occurrencesInLine = words
-        .filter((word) => word.matchType !== "None")
+        .filter((word) => word.matchType !== "None" && word.boundingBox)
         // this || clause keeps typescript happy, by this point we are guaranteed to have an array,
         //  with stuff in rather than null, but typescript doen't think so, and I can't find a
         //  type-guard-y kind of way to convince typescript.
@@ -56,11 +56,10 @@ export const mapTextSearch = (
         pageWidth,
         contextTextChunks: words.map((word) => ({
           text: word.text,
-          isHighlighted: word.matchType !== "None",
+          isHighlighted: word.matchType !== "None" && !!word.boundingBox,
         })),
         occurrencesInLine: occurrencesInLine,
       };
-
       documentResult.occurrences.push(thisOccurrence);
       documentResult.occurrencesInDocumentCount += occurrencesInLine.length;
       totalOccurrencesCount += occurrencesInLine.length;

--- a/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.ts
+++ b/polaris-ui/src/app/features/cases/hooks/use-case-details-state/map-text-search.ts
@@ -37,7 +37,7 @@ export const mapTextSearch = (
       const { id, pageIndex, words, pageHeight, pageWidth } = apiResultDocument;
 
       const occurrencesInLine = words
-        .filter((word) => word.matchType !== "None" && word.boundingBox)
+        .filter((word) => word.matchType !== "None" && !!word.boundingBox)
         // this || clause keeps typescript happy, by this point we are guaranteed to have an array,
         //  with stuff in rather than null, but typescript doen't think so, and I can't find a
         //  type-guard-y kind of way to convince typescript.

--- a/polaris-ui/src/mock-api/data/searchCaseResults.cypress.ts
+++ b/polaris-ui/src/mock-api/data/searchCaseResults.cypress.ts
@@ -89,7 +89,7 @@ const searchResults: ApiTextSearchResult[] = [
       },
       {
         boundingBox: [
-          0.6007, 6.9268, 0.9447, 6.9268, 0.9447, 7.0362, 0.6007, 7.0362,
+          1.6007, 6.9268, 1.9447, 6.9268, 1.9447, 7.0362, 0.6007, 7.0362,
         ],
         text: "drink",
         matchType: "Exact",

--- a/polaris-ui/src/mock-api/data/searchCaseResults.cypress.ts
+++ b/polaris-ui/src/mock-api/data/searchCaseResults.cypress.ts
@@ -88,7 +88,9 @@ const searchResults: ApiTextSearchResult[] = [
         confidence: 0.0,
       },
       {
-        boundingBox: null,
+        boundingBox: [
+          0.6007, 6.9268, 0.9447, 6.9268, 0.9447, 7.0362, 0.6007, 7.0362,
+        ],
         text: "drink",
         matchType: "Exact",
         confidence: 0.0,
@@ -96,7 +98,7 @@ const searchResults: ApiTextSearchResult[] = [
       {
         boundingBox: null,
         text: "zorms",
-        matchType: "None",
+        matchType: "Exact",
         confidence: 0.0,
       },
       {


### PR DESCRIPTION
https://dev.azure.com/CPSDTS/Information%20Management/_workitems/edit/28663

- Issue is caused by the search results words give  matchType as "Exact" instead of "None", which will have null bundingbox
- UI now verifies bounding box is not null and  not just the matchType when counting the search result count