### PR TITLE
Remove __cc cookie in handover

### DIFF
--- a/polaris-e2e/cypress/e2e/api.cms-launch-auth-flow.cy.ts
+++ b/polaris-e2e/cypress/e2e/api.cms-launch-auth-flow.cy.ts
@@ -1,7 +1,7 @@
 const { AUTH_HANDOVER_URL, TARGET_CASE_ID } = Cypress.env()
 
 const getUrlWithCookieParam = (cookies: string) =>
-  AUTH_HANDOVER_URL + "?__cc=" + encodeURIComponent(cookies)
+  AUTH_HANDOVER_URL + "?cc=" + encodeURIComponent(cookies)
 
 const appendQParams = (url: string, qParamObject: {}) =>
   url + "&q=" + encodeURIComponent(JSON.stringify(qParamObject))

--- a/polaris-terraform/main-terraform/nginx.js
+++ b/polaris-terraform/main-terraform/nginx.js
@@ -14,7 +14,7 @@ function _argsShim(args) {
   const serializedArgs = qs.stringify(args)
   const clonedArgsToMutate = qs.parse(serializedArgs)
   delete clonedArgsToMutate["cookie"]
-  // do not serialize cookie into our manufactured r param because cookie will be attached as the __cc param later on
+  // do not serialize cookie into our manufactured r param because cookie will be attached as the cc param later on
   const queryStringWithoutCookie = qs.stringify(clonedArgsToMutate)
 
   const clonedArgs = qs.parse(serializedArgs)
@@ -53,7 +53,7 @@ function appAuthRedirect(r) {
       r,
       `${redirectUrl}${
         redirectUrl.includes("?") ? "&" : "?"
-      }cc=${encodeURIComponent(args["cookie"] ?? "")}&__cc=${encodeURIComponent(args["cookie"] ?? "")}`
+      }cc=${encodeURIComponent(args["cookie"] ?? "")}`
     )
   } else {
     r.return(


### PR DESCRIPTION
Sends cookies only in `cc` parameter, removing the deprecated `__cc` parameter.

Note; this requires DDEI PR merge to avoid breaking handover for CWA.