### PR TITLE
HK -> CWA - Recognises documentId with no prefix added

### DIFF
--- a/polaris-ui/cypress/e2e/import-documentID-house-keeping.cy.ts
+++ b/polaris-ui/cypress/e2e/import-documentID-house-keeping.cy.ts
@@ -11,5 +11,4 @@ describe("case details page", () => {
     const pdfContainer = cy.findByTestId("div-pdfviewer-0");
     pdfContainer.should("exist");
   });
-
 });

--- a/polaris-ui/cypress/e2e/import-documentID-house-keeping.cy.ts
+++ b/polaris-ui/cypress/e2e/import-documentID-house-keeping.cy.ts
@@ -12,9 +12,4 @@ describe("case details page", () => {
     pdfContainer.should("exist");
   });
 
-  it("should return error if incorrect ID is passed", () => {
-    cy.visit("/case-details/45CV2911222/13401/101010101010");
-    const errorMsg = cy.findByTestId("txt-error-page-heading");
-    errorMsg.should("exist");
-  });
 });

--- a/polaris-ui/src/app/features/cases/presentation/case-details/accordion/AccordionDocument.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/accordion/AccordionDocument.tsx
@@ -220,9 +220,8 @@ export const AccordionDocument: React.FC<Props> = ({
       stringsOnlyPattern,
       ""
     );
-    const isDocumentValueEqual = hkDocumentId === isDocumentIdClean;
 
-    if (isDocumentValueEqual) {
+    if (hkDocumentId === isDocumentIdClean) {
       handleOpenPdf({ documentId: caseDocument.documentId });
     }
   }, [hkDocumentId]);

--- a/polaris-ui/src/app/features/cases/presentation/case-details/accordion/AccordionDocument.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/accordion/AccordionDocument.tsx
@@ -214,8 +214,16 @@ export const AccordionDocument: React.FC<Props> = ({
   useEffect(() => {
     // opens document for HouseKeeping
     // document ID is retrieved from URL
-    if (hkDocumentId) {
-      handleOpenPdf({ documentId: hkDocumentId });
+    const stringsOnlyPattern = /^[a-zA-Z]*-/;
+
+    const isDocumentIdClean = caseDocument?.documentId?.replace(
+      stringsOnlyPattern,
+      ""
+    );
+    const isDocumentValueEqual = hkDocumentId === isDocumentIdClean;
+
+    if (isDocumentValueEqual) {
+      handleOpenPdf({ documentId: caseDocument.documentId });
     }
   }, [hkDocumentId]);
 

--- a/polaris-ui/src/mock-api/data/getDocumentsList.dev.ts
+++ b/polaris-ui/src/mock-api/data/getDocumentsList.dev.ts
@@ -63,7 +63,7 @@ const documentsList: PresentationDocumentProperties[] = [
     reference: "Reference 2",
   },
   {
-    documentId: "3",
+    documentId: "CMS-3333",
     versionId: 1,
     cmsOriginalFileName: "MG05MCLOVE.pdf",
     presentationTitle: "MG05MCLOVE very long",


### PR DESCRIPTION
Passing document id to be recognised with no prefixes added:

ie: 

polaris-ui/case-details/42MZ7213221/13401/**1245451** 

instead of 

polaris-ui/case-details/42MZ7213221/13401/**CMS-1245451** 