### PR TITLE
Adds a component to save text

### DIFF
--- a/polaris-ui/cypress/e2e/case-details-page.cy.ts
+++ b/polaris-ui/cypress/e2e/case-details-page.cy.ts
@@ -758,7 +758,7 @@ describe("case details page", () => {
       keyPressAndVerifySelection("forward", "W");
       cy.findByTestId("btn-redact").should("have.length", 1);
       cy.findByTestId("btn-redact").should("be.disabled");
-      cy.realPress("Tab");
+      cy.realPress("Tab").realPress("Tab");
       cy.focused().should("have.id", "select-redaction-type");
       cy.findByTestId("select-redaction-type").select("2");
       cy.realPress("Tab");
@@ -772,7 +772,9 @@ describe("case details page", () => {
       keyPressAndVerifySelection("forward", "Y");
       cy.findByTestId("btn-redact").should("have.length", 1);
       cy.findByTestId("btn-redact").should("be.disabled");
-      cy.realPress(["Shift", "Tab"]);
+      cy.findByTestId("btn-copy").should("be.enabled");
+      cy.findByTestId("btn-copy").should("have.length", 1);
+      // cy.realPress(["Shift", "Tab"]);
       cy.focused().should("have.id", "select-redaction-type");
       cy.findByTestId("select-redaction-type").select("2");
       cy.realPress("Tab");
@@ -794,7 +796,7 @@ describe("case details page", () => {
       cy.wait(500);
       cy.realPress(["Control", ","]);
       cy.findByTestId("btn-redact").should("have.length", 1);
-      cy.realPress("Tab");
+      cy.realPress("Tab").realPress("Tab");
       cy.focused().should("have.id", "select-redaction-type");
       cy.findByTestId("select-redaction-type").select("2");
       cy.realPress("Tab");

--- a/polaris-ui/cypress/e2e/case-details-page.cy.ts
+++ b/polaris-ui/cypress/e2e/case-details-page.cy.ts
@@ -774,7 +774,7 @@ describe("case details page", () => {
       cy.findByTestId("btn-redact").should("be.disabled");
       cy.findByTestId("btn-copy").should("be.enabled");
       cy.findByTestId("btn-copy").should("have.length", 1);
-      // cy.realPress(["Shift", "Tab"]);
+      cy.realPress(["Shift", "Tab"]).realPress(["Shift", "Tab"]);
       cy.focused().should("have.id", "select-redaction-type");
       cy.findByTestId("select-redaction-type").select("2");
       cy.realPress("Tab");

--- a/polaris-ui/src/app/common/hooks/useAppInsightsTracks.tsx
+++ b/polaris-ui/src/app/common/hooks/useAppInsightsTracks.tsx
@@ -66,7 +66,8 @@ type AppInsightsTrackEventNames =
   | "Rotate Page"
   | "Undo Rotate Page"
   | "Rotate Page Right"
-  | "Rotate Page Left";
+  | "Rotate Page Left"
+  | "Copy Text Content";
 
 const eventDescription: { [key in AppInsightsTrackEventNames]: string } = {
   "Search URN":
@@ -179,6 +180,7 @@ const eventDescription: { [key in AppInsightsTrackEventNames]: string } = {
   "Undo Rotate Page": "User has cancelled page rotate",
   "Rotate Page Right": "User clicked 'Rotate page right' button",
   "Rotate Page Left": "User clicked 'Rotate page left' button",
+  "Copy Text Content": "User clicked 'Copy' button",
 };
 const useAppInsightsTrackEvent = () => {
   const { id: caseId, urn } = useParams<{ id: string; urn: string }>();

--- a/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/PdfViewer.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/PdfViewer.tsx
@@ -346,6 +346,7 @@ export const PdfViewer: React.FC<Props> = ({
                           : undefined
                       }
                       redactionTypesData={redactionTypesData}
+                      onRedactionCopy={() => hideTipAndSelection()}
                       onConfirm={(
                         redactionType: RedactionTypeData,
                         actionType: PIIRedactionStatus | "redact"

--- a/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/RedactButton.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/RedactButton.tsx
@@ -5,6 +5,7 @@ import { useFocusTrap } from "../../../../../common/hooks/useFocusTrap";
 import { useLastFocus } from "../../../../../common/hooks/useLastFocus";
 import { RedactionTypeData } from "../../../domain/redactionLog/RedactionLogData";
 import { PIIRedactionStatus } from "../../../domain/NewPdfHighlight";
+import { ACCEPT, REDACT, COPY } from "../utils/constants";
 
 type Props = {
   searchPIIData?: {
@@ -125,7 +126,7 @@ export const RedactButton: React.FC<Props> = ({
             data-testid="btn-redact"
             id="btn-redact"
           >
-            Redact
+            {REDACT}
           </Button>
         )}
         <Button
@@ -133,7 +134,7 @@ export const RedactButton: React.FC<Props> = ({
           data-testid="btn-copy"
           id="btn-copy"
         >
-          Copy
+          {COPY}
         </Button>
 
         {searchPIIData && (
@@ -144,7 +145,7 @@ export const RedactButton: React.FC<Props> = ({
               data-testid="btn-accept"
               id="btn-accept"
             >
-              Accept
+              {ACCEPT}
             </Button>
             {searchPIIData.count > 1 && (
               <Button

--- a/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/RedactButton.tsx
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/pdf-viewer/RedactButton.tsx
@@ -17,6 +17,7 @@ type Props = {
     redactionType: { id: string; name: string },
     actionType: PIIRedactionStatus | "redact"
   ) => void;
+  onRedactionCopy: () => void;
 };
 
 const getMappedRedactionTypes = (data: RedactionTypeData[]) => {
@@ -39,6 +40,7 @@ export const RedactButton: React.FC<Props> = ({
   onConfirm,
   redactionTypesData,
   searchPIIData,
+  onRedactionCopy,
 }) => {
   const [redactionType, setRedactionType] = useState<string>("");
   useFocusTrap("#redact-modal");
@@ -46,6 +48,12 @@ export const RedactButton: React.FC<Props> = ({
 
   const handleSearchPIIBtnClick = (actionType: PIIRedactionStatus) => {
     onConfirm({ id: "", name: "" }, actionType);
+  };
+
+  const handleCopyRedactionText = () => {
+    const selectionText = window.getSelection()?.toString();
+    if (selectionText) navigator.clipboard.writeText(selectionText);
+    onRedactionCopy();
   };
 
   const handleRedactBtnClick = () => {
@@ -120,6 +128,14 @@ export const RedactButton: React.FC<Props> = ({
             Redact
           </Button>
         )}
+        <Button
+          onClick={handleCopyRedactionText}
+          data-testid="btn-copy"
+          id="btn-copy"
+        >
+          Copy
+        </Button>
+
         {searchPIIData && (
           <>
             <Button

--- a/polaris-ui/src/app/features/cases/presentation/case-details/utils/constants.ts
+++ b/polaris-ui/src/app/features/cases/presentation/case-details/utils/constants.ts
@@ -1,0 +1,3 @@
+export const COPY = "Copy";
+export const REDACT = "Redact";
+export const ACCEPT = "Accept";


### PR DESCRIPTION
Adds a button on the redaction modal allowing copying selected text to memory, so users could save it for later use.