### PR TITLE
Feature/fct2 5984 azsearch costing

### DIFF
--- a/polaris-terraform/main-terraform/dev.tfvars
+++ b/polaris-terraform/main-terraform/dev.tfvars
@@ -155,7 +155,7 @@ image_conversion_redaction = {
 }
 
 search_service_config = {
-  replica_count                 = 3
+  replica_count                 = 2
   partition_count               = 1
   is_dynamic_throttling_enabled = true
 }

--- a/polaris-terraform/main-terraform/prod.tfvars
+++ b/polaris-terraform/main-terraform/prod.tfvars
@@ -155,7 +155,7 @@ image_conversion_redaction = {
 
 search_service_config = {
   replica_count                 = 3
-  partition_count               = 4
+  partition_count               = 2
   is_dynamic_throttling_enabled = true
 }
 

--- a/polaris-terraform/main-terraform/qa.tfvars
+++ b/polaris-terraform/main-terraform/qa.tfvars
@@ -155,7 +155,7 @@ image_conversion_redaction = {
 }
 
 search_service_config = {
-  replica_count                 = 3
+  replica_count                 = 2
   partition_count               = 1
   is_dynamic_throttling_enabled = true
 }


### PR DESCRIPTION
Phase 2 changes for azure search optimisation.

Dev/QA - Replica count has been reduced down to 2. Keeping at 2 to support concurrent index and query operations to avoid developer experience being impacted.
Prod - Replica count reduced from 4 to 2. This will leave 50GB of storage available and there is current 32GB in use. 