### PR TITLE
Upgrade to latest supported Node stack

### DIFF
--- a/polaris-terraform/main-terraform/app-service-spa-staging.tf
+++ b/polaris-terraform/main-terraform/app-service-spa-staging.tf
@@ -88,7 +88,7 @@ resource "azurerm_linux_web_app_slot" "as_web_polaris_staging1" {
     vnet_route_all_enabled = true
 
     application_stack {
-      node_version = "22-lts"
+      node_version = "20-lts"
     }
   }
 

--- a/polaris-terraform/main-terraform/app-service-spa-staging.tf
+++ b/polaris-terraform/main-terraform/app-service-spa-staging.tf
@@ -88,7 +88,7 @@ resource "azurerm_linux_web_app_slot" "as_web_polaris_staging1" {
     vnet_route_all_enabled = true
 
     application_stack {
-      node_version = "18-lts"
+      node_version = "22-lts"
     }
   }
 

--- a/polaris-terraform/main-terraform/app-service-spa.tf
+++ b/polaris-terraform/main-terraform/app-service-spa.tf
@@ -95,7 +95,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     vnet_route_all_enabled = true
 
     application_stack {
-      node_version = "22-lts"
+      node_version = "20-lts"
     }
   }
 

--- a/polaris-terraform/main-terraform/app-service-spa.tf
+++ b/polaris-terraform/main-terraform/app-service-spa.tf
@@ -95,7 +95,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
     vnet_route_all_enabled = true
 
     application_stack {
-      node_version = "18-lts"
+      node_version = "22-lts"
     }
   }
 

--- a/polaris-terraform/main-terraform/main.tf
+++ b/polaris-terraform/main-terraform/main.tf
@@ -1,30 +1,30 @@
 terraform {
-  required_version = ">= 1.12.1"
+  required_version = ">= 1.5.3"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.23.0"
+      version = "3.87.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "3.4.0"
+      version = "2.45.0"
     }
 
     restapi = {
       source  = "Mastercard/restapi"
-      version = "2.0.1"
+      version = "1.18.2"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "3.7.1"
+      version = "3.5.1"
     }
 
     azapi = {
       source  = "Azure/azapi"
-      version = "2.4.0"
+      version = "1.10.0"
     }
   }
 

--- a/polaris-terraform/main-terraform/main.tf
+++ b/polaris-terraform/main-terraform/main.tf
@@ -1,30 +1,30 @@
 terraform {
-  required_version = ">= 1.5.3"
+  required_version = ">= 1.12.1"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.87.0"
+      version = "4.23.0"
     }
 
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.45.0"
+      version = "3.4.0"
     }
 
     restapi = {
       source  = "Mastercard/restapi"
-      version = "1.18.2"
+      version = "2.0.1"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1"
+      version = "3.7.1"
     }
 
     azapi = {
       source  = "Azure/azapi"
-      version = "1.10.0"
+      version = "2.4.0"
     }
   }
 


### PR DESCRIPTION
Node 18 is deprecated in Azure App Service therefore increasing version to latest Node 20 LTS. Dev's should also increase to Node 20 locally.