### PR TITLE
Feature/fct2 6445 ocr auth bug

### DIFF
--- a/polaris-terraform/main-terraform/app-service-proxy.tf
+++ b/polaris-terraform/main-terraform/app-service-proxy.tf
@@ -216,7 +216,7 @@ resource "azurerm_linux_web_app" "polaris_proxy" {
   }
 }
 
-module "azurerm_app_reg_polaris_proxy" {
+module "azurerm_app_reg_polaris_proxy" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "${local.global_resource_name}-cmsproxy-appreg"
   identifier_uris         = ["https://CPSGOVUK.onmicrosoft.com/${local.global_resource_name}-cmsproxy"]
@@ -241,7 +241,7 @@ resource "azuread_application_password" "asap_polaris_cms_proxy" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_sp_polaris_cms_proxy" {
+module "azurerm_service_principal_sp_polaris_cms_proxy" {  # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_polaris_proxy.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/app-service-spa.tf
+++ b/polaris-terraform/main-terraform/app-service-spa.tf
@@ -196,7 +196,7 @@ resource "azurerm_linux_web_app" "as_web_polaris" {
   }
 }
 
-module "azurerm_app_reg_as_web_polaris" {
+module "azurerm_app_reg_as_web_polaris" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "as-web-${local.global_resource_name}-appreg"
   identifier_uris         = ["https://CPSGOVUK.onmicrosoft.com/as-web-${local.global_resource_name}"]
@@ -273,7 +273,7 @@ resource "azuread_application_password" "e2e_test_secret" {
   }
 }
 
-module "azurerm_service_principal_sp_polaris_web" {
+module "azurerm_service_principal_sp_polaris_web" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_as_web_polaris.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-coordinator.tf
+++ b/polaris-terraform/main-terraform/function-coordinator.tf
@@ -148,7 +148,7 @@ resource "azurerm_linux_function_app" "fa_coordinator" {
   }
 }
 
-module "azurerm_app_reg_fa_coordinator" {
+module "azurerm_app_reg_fa_coordinator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "fa-${local.global_resource_name}-coordinator-appreg"
   identifier_uris         = ["api://fa-${local.global_resource_name}-coordinator"]
@@ -168,7 +168,7 @@ module "azurerm_app_reg_fa_coordinator" {
   tags = ["terraform"]
 }
 
-module "azurerm_service_principal_fa_coordinator" {
+module "azurerm_service_principal_fa_coordinator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_coordinator.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-gateway.tf
+++ b/polaris-terraform/main-terraform/function-gateway.tf
@@ -163,7 +163,7 @@ resource "azurerm_linux_function_app" "fa_polaris" {
   depends_on = [azurerm_storage_account.sa_gateway, azapi_resource.polaris_sa_gateway_file_share]
 }
 
-module "azurerm_app_reg_fa_polaris" {
+module "azurerm_app_reg_fa_polaris" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "fa-${local.global_resource_name}-gateway-appreg"
   identifier_uris         = ["https://CPSGOVUK.onmicrosoft.com/fa-${local.global_resource_name}-gateway"]
@@ -221,7 +221,7 @@ resource "azuread_application_password" "faap_polaris_app_service" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_sp_polaris_gateway" {
+module "azurerm_service_principal_sp_polaris_gateway" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_polaris.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-maintenance.tf
+++ b/polaris-terraform/main-terraform/function-maintenance.tf
@@ -56,7 +56,7 @@ resource "azurerm_linux_function_app" "fa_polaris_maintenance" {
   depends_on = [azurerm_storage_account.sa_gateway, azapi_resource.polaris_sa_maintenance_file_share]
 }
 
-module "azurerm_app_reg_fa_maintenance" {
+module "azurerm_app_reg_fa_maintenance" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   count = var.env == "dev" ? 1 : 0
 
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
@@ -84,7 +84,7 @@ resource "azuread_application_password" "faap_fa_maintenance_app_service" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_fa_maintenance" {
+module "azurerm_service_principal_fa_maintenance" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   count = var.env == "dev" ? 1 : 0
 
   source                       = "./modules/terraform-azurerm-azuread_service_principal"

--- a/polaris-terraform/main-terraform/function-pdf-generator.tf
+++ b/polaris-terraform/main-terraform/function-pdf-generator.tf
@@ -104,7 +104,7 @@ resource "azurerm_windows_function_app" "fa_pdf_generator" {
   }
 }
 
-module "azurerm_app_reg_fa_pdf_generator" {
+module "azurerm_app_reg_fa_pdf_generator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "fa-${local.global_resource_name}-pdf-generator-appreg"
   identifier_uris         = ["api://fa-${local.global_resource_name}-pdf-generator"]
@@ -138,7 +138,7 @@ resource "azuread_application_password" "faap_fa_pdf_generator_app_service" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_fa_pdf_generator" {
+module "azurerm_service_principal_fa_pdf_generator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_pdf_generator.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-pdf-redactor.tf
+++ b/polaris-terraform/main-terraform/function-pdf-redactor.tf
@@ -104,7 +104,7 @@ resource "azurerm_windows_function_app" "fa_pdf_redactor" {
   }
 }
 
-module "azurerm_app_reg_fa_pdf_redactor" {
+module "azurerm_app_reg_fa_pdf_redactor" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "fa-${local.global_resource_name}-pdf-redactor-appreg"
   identifier_uris         = ["api://fa-${local.global_resource_name}-pdf-redactor"]
@@ -138,7 +138,7 @@ resource "azuread_application_password" "faap_fa_pdf_redactor_app_service" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_fa_pdf_redactor" {
+module "azurerm_service_principal_fa_pdf_redactor" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_pdf_redactor.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-pdf-thumbnail-generator.tf
+++ b/polaris-terraform/main-terraform/function-pdf-thumbnail-generator.tf
@@ -107,7 +107,7 @@ resource "azurerm_windows_function_app" "fa_pdf_thumbnail_generator" {
   }
 }
 
-module "azurerm_app_reg_fa_pdf_thumbnail_generator" {
+module "azurerm_app_reg_fa_pdf_thumbnail_generator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                  = "./modules/terraform-azurerm-azuread-app-registration"
   display_name            = "fa-${local.global_resource_name}-pdf-thumb-gen-appreg"
   identifier_uris         = ["api://fa-${local.global_resource_name}-pdf-thumb-gen"]
@@ -141,7 +141,7 @@ resource "azuread_application_password" "faap_fa_pdf_thumbnail_generator_app_ser
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_fa_pdf_thumbnail_generator" {
+module "azurerm_service_principal_fa_pdf_thumbnail_generator" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_pdf_thumbnail_generator.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/function-text-extractor.tf
+++ b/polaris-terraform/main-terraform/function-text-extractor.tf
@@ -102,8 +102,8 @@ resource "azurerm_linux_function_app" "fa_text_extractor" {
   }
 }
 
-module "azurerm_app_reg_fa_text_extractor" {
-  source                  = "./modules/terraform-azurerm-azuread-app-registration"
+module "azurerm_app_reg_fa_text_extractor" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
+  source                  = "./modules/terraform-azurerm-azuread-app-registration" 
   display_name            = "fa-${local.global_resource_name}-text-extractor-appreg"
   identifier_uris         = ["api://fa-${local.global_resource_name}-text-extractor"]
   prevent_duplicate_names = true
@@ -136,7 +136,7 @@ resource "azuread_application_password" "faap_fa_text_extractor_app_service" {
   end_date_relative     = "17520h"
 }
 
-module "azurerm_service_principal_fa_text_extractor" {
+module "azurerm_service_principal_fa_text_extractor" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
   application_id               = module.azurerm_app_reg_fa_text_extractor.client_id
   app_role_assignment_required = false

--- a/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/main.tf
+++ b/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/main.tf
@@ -142,11 +142,12 @@ app roles are currently being managed outside of teraform. Commenting out the be
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      app_role_ids,
+      app_role
+    ]
+  }
+  
 }
-
-
-
-
-
-
-

--- a/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/main.tf
+++ b/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/main.tf
@@ -111,6 +111,8 @@ resource "azuread_application" "main" {
     }
   }
 
+/*
+app roles are currently being managed outside of teraform. Commenting out the below block to make sure terraform does not track the app_role attribute.
   dynamic "app_role" {
     for_each = var.app_role != null ? var.app_role : []
     content {
@@ -122,6 +124,7 @@ resource "azuread_application" "main" {
       value                = lookup(app_role.value, "value", null)
     }
   }
+*/
 
   dynamic "required_resource_access" {
     for_each = var.required_resource_access != null ? var.required_resource_access : []

--- a/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/output.tf
+++ b/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread-app-registration/output.tf
@@ -27,8 +27,9 @@ output "oauth2_permission_scope_ids" {
   description = "A mapping of OAuth2.0 permission scope values to scope IDs, intended to be useful when referencing permission scopes in other resources in your configuration."
   value       = azuread_application.main.oauth2_permission_scope_ids
 }
-
+/*
 output "app_role_ids" {
   description = "A mapping of app role values to app role IDs, intended to be useful when referencing app roles in other resources in your configuration."
   value       = azuread_application.main.app_role_ids
 }
+*/

--- a/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread_service_principal/main.tf
+++ b/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread_service_principal/main.tf
@@ -30,6 +30,13 @@ resource "azuread_service_principal" "main" {
       hide                  = lookup(var.feature_tags, "hide", null)
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      app_role_ids,
+      app_roles
+    ]
+  }
 }
 
 

--- a/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread_service_principal/output.tf
+++ b/polaris-terraform/main-terraform/modules/terraform-azurerm-azuread_service_principal/output.tf
@@ -1,9 +1,11 @@
 # Outputs of azuread_service_principal resource
 
+/*
 output "app_role_ids" {
   description = "A mapping of app role values to app role IDs, as published by the associated application, intended to be useful when referencing app roles in other resources in your configuration."
   value       = azuread_service_principal.main.app_role_ids
 }
+*/
 
 output "app_roles" {
   description = "A list of app roles published by the associated application."
@@ -70,4 +72,3 @@ output "type" {
   description = "Identifies whether the service principal represents an application or a managed identity."
   value       = azuread_service_principal.main.type
 }
-


### PR DESCRIPTION
app roles are currently being managed outside of terraform. Adding lifecycle blocks to prevent terraform from changing the values back to null.