### PR TITLE
#FCT2-7367 - add global nav blob storage to auth-handover whitelist

### DIFF
--- a/polaris-terraform/main-terraform/dev.tfvars
+++ b/polaris-terraform/main-terraform/dev.tfvars
@@ -76,7 +76,7 @@ cms_details = {
 }
 
 wm_task_list_host_name  = "https://cps-dev.outsystemsenterprise.com"
-auth_handover_whitelist = "/auth-refresh-inbound,https://cps-dev.outsystemsenterprise.com/WorkManagementApp/,https://cps-dev.outsystemsenterprise.com/CaseReview/"
+auth_handover_whitelist = "/auth-refresh-inbound,https://cps-dev.outsystemsenterprise.com/WorkManagementApp/,https://cps-dev.outsystemsenterprise.com/CaseReview/,https://sacpsglobalcomponents.blob.core.windows.net/"
 
 app_service_log_retention       = 90
 app_service_log_total_retention = 2555

--- a/polaris-terraform/main-terraform/qa.tfvars
+++ b/polaris-terraform/main-terraform/qa.tfvars
@@ -76,7 +76,7 @@ cms_details = {
 }
 
 wm_task_list_host_name  = "https://cps-tst.outsystemsenterprise.com"
-auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/WorkManagementApp/,https://cps-tst.outsystemsenterprise.com/CaseReview/,https://housekeeping-fn-staging.int.cps.gov.uk/"
+auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/WorkManagementApp/,https://cps-tst.outsystemsenterprise.com/CaseReview/,https://housekeeping-fn-staging.int.cps.gov.uk/,https://sacpsglobalcomponents.blob.core.windows.net/"
 
 app_service_log_retention       = 90
 app_service_log_total_retention = 2555


### PR DESCRIPTION
The change allows us to send FCT app auth redirect flows onwards to an endpoint that the global components project team can control. This allows us to keep working on global menu work without continually having to submit changes to the Polaris repo.

- This will not affect any existing auth/reauth flows used by the apps.
- Out endpoint will itself redirect auth flows to the intended application landing pages, but allows us to manipulate the query string parameters. 
- This affects pre-prod (dev and qa) only.
- The mechanism involved is temporary.  Once we learn more we can formulate a "proper" change to the auth handover logic.
