### PR TITLE
fix: setting partition count back to 4 after prod latency concerns

### DIFF
--- a/polaris-terraform/main-terraform/prod.tfvars
+++ b/polaris-terraform/main-terraform/prod.tfvars
@@ -156,7 +156,7 @@ image_conversion_redaction = {
 
 search_service_config = {
   replica_count                 = 3
-  partition_count               = 2
+  partition_count               = 4
   is_dynamic_throttling_enabled = true
 }
 


### PR DESCRIPTION
Performance degradation was noticed when the partition count was reduced from 4 to 2. This PR will change it back to 4 for stability.