### PR TITLE
#FCT2-8251 - (temporarily) add dev outsystems to the qa proxy handover whitelist

### DIFF
--- a/polaris-terraform/main-terraform/qa.tfvars
+++ b/polaris-terraform/main-terraform/qa.tfvars
@@ -76,7 +76,7 @@ cms_details = {
 }
 
 wm_task_list_host_name  = "https://cps-tst.outsystemsenterprise.com"
-auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/,https://housekeeping-fn-staging.int.cps.gov.uk/"
+auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/,https://housekeeping-fn-staging.int.cps.gov.uk/,https://cps-dev.outsystemsenterprise.com/"
 
 app_service_log_retention       = 90
 app_service_log_total_retention = 2555


### PR DESCRIPTION
Because the OutSystems guys aren't moving very quickly