### PR TITLE
temporarily disabling SP from dev

### DIFF
--- a/polaris-terraform/main-terraform/app-service-spa.tf
+++ b/polaris-terraform/main-terraform/app-service-spa.tf
@@ -275,6 +275,7 @@ resource "azuread_application_password" "e2e_test_secret" {
 
 module "azurerm_service_principal_sp_polaris_web" { # Note, app roles are currently being managed outside of terraform and it's functionality has been commented out from the module.
   source                       = "./modules/terraform-azurerm-azuread_service_principal"
+  account_enabled              = var.sp_polaris_web_enabled # this SP has been temporarily disabled for Dev on the 29/07/2025.
   application_id               = module.azurerm_app_reg_as_web_polaris.client_id
   app_role_assignment_required = false
   owners                       = [data.azurerm_client_config.current.object_id]

--- a/polaris-terraform/main-terraform/dev.tfvars
+++ b/polaris-terraform/main-terraform/dev.tfvars
@@ -174,3 +174,5 @@ coordinator = {
 }
 
 cps_global_components_url="https://sacpsglobalcomponents.blob.core.windows.net/dev/cps-global-components.js"
+
+sp_polaris_web_enabled = false # this SP has been temporarily disabled for Dev on the 29/07/2025.

--- a/polaris-terraform/main-terraform/prod.tfvars
+++ b/polaris-terraform/main-terraform/prod.tfvars
@@ -173,3 +173,5 @@ coordinator = {
 }
 
 cps_global_components_url="https://sacpsglobalcomponents.blob.core.windows.net/prod/cps-global-components.js"
+
+sp_polaris_web_enabled = true

--- a/polaris-terraform/main-terraform/qa.tfvars
+++ b/polaris-terraform/main-terraform/qa.tfvars
@@ -174,3 +174,5 @@ coordinator = {
 }
 
 cps_global_components_url="https://sacpsglobalcomponents.blob.core.windows.net/test/cps-global-components.js"
+
+sp_polaris_web_enabled = true

--- a/polaris-terraform/main-terraform/uat.tfvars
+++ b/polaris-terraform/main-terraform/uat.tfvars
@@ -174,3 +174,5 @@ coordinator = {
 }
 
 cps_global_components_url="https://sacpsglobalcomponents.blob.core.windows.net/test/cps-global-components.js"
+
+sp_polaris_web_enabled = true

--- a/polaris-terraform/main-terraform/variables.tf
+++ b/polaris-terraform/main-terraform/variables.tf
@@ -378,3 +378,8 @@ variable "coordinator" {
 variable "cps_global_components_url" {
   type = string
 }
+
+variable "sp_polaris_web_enabled" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
Added functionality to declare whether a service principal for polaris web is set to enabled or not.
This is a temporary setting to ensure that terraform stops enabling the principal in dev which has been temporarily disabled.
