### PR TITLE
Feature/fct2 9793 npm ci

### DIFF
--- a/polaris-devops-pipelines/deployments_v2/polaris-pr.yml
+++ b/polaris-devops-pipelines/deployments_v2/polaris-pr.yml
@@ -534,7 +534,7 @@ stages:
             inputs:
               command: "ci"
               workingDir: "polaris-ui"
-            displayName: "npm ci"
+            displayName: "npm install"
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/deployments_v2/polaris-pr.yml
+++ b/polaris-devops-pipelines/deployments_v2/polaris-pr.yml
@@ -532,9 +532,9 @@ stages:
 
           - task: Npm@1
             inputs:
-              command: "install"
+              command: "ci"
               workingDir: "polaris-ui"
-            displayName: "npm install"
+            displayName: "npm ci"
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/deployments_v2/stages/stage_publish-all-artifacts.yml
+++ b/polaris-devops-pipelines/deployments_v2/stages/stage_publish-all-artifacts.yml
@@ -295,7 +295,7 @@ stages:
             inputs:
               command: "ci"
               workingDir: "polaris-ui"
-            displayName: "npm ci"
+            displayName: "npm install"
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/deployments_v2/stages/stage_publish-all-artifacts.yml
+++ b/polaris-devops-pipelines/deployments_v2/stages/stage_publish-all-artifacts.yml
@@ -293,9 +293,9 @@ stages:
 
           - task: Npm@1
             inputs:
-              command: "install"
+              command: "ci"
               workingDir: "polaris-ui"
-            displayName: "npm install"
+            displayName: "npm ci"
 
           - task: Npm@1
             inputs:

--- a/polaris-devops-pipelines/scale-set/build-agent.sh
+++ b/polaris-devops-pipelines/scale-set/build-agent.sh
@@ -64,7 +64,7 @@ curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /us
 echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update && sudo apt-get install yarn
 echo '==== Install Cypress ===='
-sudo npm install cypress --save-dev
+sudo npm install cypress@15.0.0 --save-dev
 sudo apt-get install -y libgtk2.0-0
 sudo apt-get install -y libgtk-3-0
 sudo apt-get install -y libgbm-dev

--- a/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-a.yml
+++ b/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-a.yml
@@ -20,9 +20,9 @@ jobs:
 
       - task: Npm@1
         inputs:
-          command: "install"
+          command: "ci"
           workingDir: "polaris-e2e"
-        displayName: "npm install"
+        displayName: "npm ci"
         
       #before running the tests replace the clientId placeholder in env-specific config file
       - bash: |

--- a/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-a.yml
+++ b/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-a.yml
@@ -22,7 +22,7 @@ jobs:
         inputs:
           command: "ci"
           workingDir: "polaris-e2e"
-        displayName: "npm ci"
+        displayName: "npm install"
         
       #before running the tests replace the clientId placeholder in env-specific config file
       - bash: |

--- a/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-b.yml
+++ b/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-b.yml
@@ -20,9 +20,9 @@ jobs:
 
       - task: Npm@1
         inputs:
-          command: "install"
+          command: "ci"
           workingDir: "polaris-e2e"
-        displayName: "npm install"
+        displayName: "npm ci"
         
       #before running the tests replace the clientId placeholder in env-specific config file
       - bash: |

--- a/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-b.yml
+++ b/polaris-e2e/pipelines/stages/jobs/job_run-cypress-tests-b.yml
@@ -22,7 +22,7 @@ jobs:
         inputs:
           command: "ci"
           workingDir: "polaris-e2e"
-        displayName: "npm ci"
+        displayName: "npm install"
         
       #before running the tests replace the clientId placeholder in env-specific config file
       - bash: |

--- a/polaris-ui/package-lock.json
+++ b/polaris-ui/package-lock.json
@@ -11,8 +11,8 @@
         "@azure/msal-browser": "^2.38.0",
         "@azure/msal-react": "^1.5.3",
         "@cypress/instrument-cra": "^1.4.0",
-        "@microsoft/applicationinsights-react-js": "^3.4.2",
-        "@microsoft/applicationinsights-web": "^2.8.14",
+        "@microsoft/applicationinsights-react-js": "^18.3.6",
+        "@microsoft/applicationinsights-web": "^3.3.6",
         "@microsoft/microsoft-graph-client": "^3.0.0",
         "@testing-library/cypress": "^10.0.3",
         "@testing-library/jest-dom": "^5.11.4",
@@ -693,6 +693,7 @@
       "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -2546,6 +2547,7 @@
       "resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.14.3.tgz",
       "integrity": "sha512-wU7XAIgcAkj8fnFySPYejK1nR1OEYw1WicoPBRb2dHK+XQX0MfvJnyMftZrlbofymMpwr2ylTeuDRWu9Tk1jyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cypress/webpack-preprocessor": "^6.0.0",
         "chalk": "4.1.2",
@@ -3525,139 +3527,173 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/applicationinsights-analytics-js": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.8.18.tgz",
       "integrity": "sha512-YfuUyTBx8HNGgIwg8N01iwsIO6LaqApNwGXw5YunAw+hqYR6jRmYlseQGTPFvKtq1ebEPJiwK0LjIQw/fOcxHQ==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.8.18",
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.3.10",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.8.18.tgz",
       "integrity": "sha512-KNYk8qeci8AcWKZUqgCElEr1Ef5G+iudq1mN57Sc/8hUONNp2fTfWh1Cm+RUTRIEWAC29uUWGyLhSqiTF3ox1w==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.8.18",
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-common": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.8.18.tgz",
       "integrity": "sha512-/PBRmRL6rFCoO3vWpIEHuFnu+TinEYRKWOj+I+XVUH5myZpv+nYvaRdwryVTkmCYxLyL9kxtNn7hQx8DBlhdSw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.18.tgz",
       "integrity": "sha512-yPHRZFLpnEO0uSgFPM1BLMRRwjoten9YBbn4pJRbCT4PigLnj748knmWsMwXIdcehtkRTYz78kPYa/LWP7nvmA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.8.18.tgz",
       "integrity": "sha512-XW3m1DEXo2CkTUEeBzXGjoMjud6b1Y1J6W1Nz0RJ3IMC5ptbSOeen5rRDSzcBEUZN75vWvbGmhxVuQTXnnIu2g==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.8.18",
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-properties-js": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.8.18.tgz",
       "integrity": "sha512-WucPqEzgT20JhjwOPQhgBSal6tlKldUz3c6j5Kpj4Rej95c2vvm1t14lI/p9SvOjZDRK5dMfkuQtvFG7NrUlIA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "2.8.18",
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-react-js": {
-      "version": "3.4.3",
+      "version": "18.3.6",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-3.4.3.tgz",
       "integrity": "sha512-+IIPDYU7DKBwByN7lK/mkMGrnWMGdyIsEZfDzBh/fKDZgGGGgH9B3WHej+vIpdwBcVaPbYx++lonTshn56C9/A==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "^2.8.14",
-        "@microsoft/applicationinsights-core-js": "^2.8.14",
-        "@microsoft/applicationinsights-shims": "^2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.9"
+        "@microsoft/applicationinsights-common": "^3.3.6",
+        "@microsoft/applicationinsights-core-js": "^3.3.6",
+        "@microsoft/applicationinsights-shims": "^3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
       },
       "peerDependencies": {
         "history": ">= 4.10.1",
-        "react": ">= 17.0.1",
+        "react": ">= 18.0.0",
         "tslib": "*"
       }
     },
     "node_modules/@microsoft/applicationinsights-shims": {
-      "version": "2.0.2",
+      "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-2.0.2.tgz",
       "integrity": "sha512-PoHEgsnmcqruLNHZ/amACqdJ6YYQpED0KSRe6J7gIJTtpZC1FfFU9b1fmDKDKtFoUSrPzEh1qzO3kmRZP0betg==",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
     },
     "node_modules/@microsoft/applicationinsights-web": {
-      "version": "2.8.18",
+      "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.8.18.tgz",
       "integrity": "sha512-n6gW9WXr/oHrt2S8waXjYoBqzhPChJNoTPlKm+pwtO3iP+I8dQDuf8Q02RKLgCaWzvEhO/1GSznCECBX0jP+gg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-analytics-js": "2.8.18",
-        "@microsoft/applicationinsights-channel-js": "2.8.18",
-        "@microsoft/applicationinsights-common": "2.8.18",
-        "@microsoft/applicationinsights-core-js": "2.8.18",
-        "@microsoft/applicationinsights-dependencies-js": "2.8.18",
-        "@microsoft/applicationinsights-properties-js": "2.8.18",
-        "@microsoft/applicationinsights-shims": "2.0.2",
-        "@microsoft/dynamicproto-js": "^1.1.11"
+        "@microsoft/applicationinsights-analytics-js": "3.3.10",
+        "@microsoft/applicationinsights-cfgsync-js": "3.3.10",
+        "@microsoft/applicationinsights-channel-js": "3.3.10",
+        "@microsoft/applicationinsights-common": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-dependencies-js": "3.3.10",
+        "@microsoft/applicationinsights-properties-js": "3.3.10",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
       "peerDependencies": {
-        "tslib": "*"
+        "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/dynamicproto-js": {
-      "version": "1.1.11",
+      "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-1.1.11.tgz",
       "integrity": "sha512-gNw9z9LbqLV+WadZ6/MMrWwO3e0LuoUH1wve/1iPsBNbgqeVCiB0EZFNNj2lysxS2gkqoF9hmyVaG3MoM1BkxA==",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+      }
     },
     "node_modules/@microsoft/microsoft-graph-client": {
       "version": "3.0.7",
@@ -3709,6 +3745,17 @@
         "outvariant": "^1.2.0",
         "strict-event-emitter": "^0.2.0"
       }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.5.4",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.12.5",
+      "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -9550,6 +9597,7 @@
     },
     "node_modules/env-cmd": {
       "version": "10.1.0",
+      "license": "MIT",
       "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
       "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
       "dependencies": {
@@ -11493,20 +11541,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",


### PR DESCRIPTION
pipelines have been updated to use npm ci instead of install.
package lock file has been updated to be up to date with the package file, as there was drift between the two files originally.