### PR TITLE
FCT2-9903 Whitelist LCC application in staging for auth handover

### DIFF
--- a/polaris-terraform/main-terraform/qa.tfvars
+++ b/polaris-terraform/main-terraform/qa.tfvars
@@ -76,7 +76,7 @@ cms_details = {
 }
 
 wm_task_list_host_name  = "https://cps-tst.outsystemsenterprise.com"
-auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/,https://housekeeping-fn-staging.int.cps.gov.uk/,/task-list"
+auth_handover_whitelist = "/auth-refresh-inbound,https://cps-tst.outsystemsenterprise.com/,https://housekeeping-fn-staging.int.cps.gov.uk/,/task-list,https://fa-lacc-api-staging.azurewebsites.net/"
 
 app_service_log_retention       = 90
 app_service_log_total_retention = 2555


### PR DESCRIPTION
Adding Large and Complex Cases (LCC) default domain to auth handover whitelist in staging. The LCC application needs to utilise the same cookie handoff mechanism as used by Housekeeping service as part of private beta testing and rollout.