### PR TITLE
#FCT2-12605 - change CMS tasklist button to go via standard auth handover mechanism

### DIFF
--- a/polaris-terraform/main-terraform/nginx.conf
+++ b/polaris-terraform/main-terraform/nginx.conf
@@ -70,8 +70,6 @@ http {
         set $ieaction "nonie+${ieaction}";
     }
     
-    js_var $taskListHostAddress "${WM_TASK_LIST_HOST_NAME}";
-
     # Make environment variables available to Javascript functions, these are required for processing which
     # CMS environment to proxy to. These are used in a few location blocks, so have elected to make these global.
     js_var $defaultUpstreamCmsIpCorsham "${DEFAULT_UPSTREAM_CMS_IP_CORSHAM}";
@@ -458,7 +456,7 @@ http {
 
     # CMS UI -> Task List cookie handover
     location /task-list {
-      js_content nginx.taskListAuthRedirect;
+      return 302 https://polaris-qa-notprod.cps.gov.uk/polaris?r=https%3A%2F%2Fcps-tst.outsystemsenterprise.com%2FCasework_Patterns%2Fauth-handover-test.html%3Fstage%3Dos-outbound%26r%3D${WM_TASK_LIST_HOST_NAME}%252FWorkManagementApp%252FTaskList;
     }
 
     # Polaris auth failure redirects here.  If we get a DDEI auth failure then we have not got correct CMS cookies for the user.

--- a/polaris-terraform/main-terraform/nginx.js
+++ b/polaris-terraform/main-terraform/nginx.js
@@ -128,14 +128,4 @@ function polarisAuthRedirect(r) {
   _redirectToAbsoluteUrl(r, `/init?${querystring}`)
 }
 
-function taskListAuthRedirect(r) {
-  const args = _argsShim(r.args)
-  const taskListHostAddress = r.variables["taskListHostAddress"] ?? ""
-  const cookie = encodeURIComponent(args["cc"] ?? r.headersIn.Cookie ?? "")
-  _redirectToAbsoluteUrl(
-    r,
-    `${taskListHostAddress}/WorkManagementApp/Redirect?Cookie=${cookie}`
-  )
-}
-
-export default { polarisAuthRedirect, taskListAuthRedirect, appAuthRedirect }
+export default { polarisAuthRedirect, appAuthRedirect }


### PR DESCRIPTION
Unify tasklist handover with the standard C-button auth handover mechanism