### PR TITLE
FCT2-18058 - Identify API clients using Header

### DIFF
--- a/polaris-gateway/Middleware/RequestValidationMiddleware.cs
+++ b/polaris-gateway/Middleware/RequestValidationMiddleware.cs
@@ -1,17 +1,17 @@
-﻿using Common.Extensions;
-using Common.Telemetry;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Middleware;
-using PolarisGateway.Validators;
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.Functions.Worker.Http;
-using Common.Exceptions;
 using Common.Configuration;
 using Common.Constants;
-using Microsoft.ApplicationInsights.DataContracts;
+using Common.Exceptions;
+using Common.Extensions;
+using Common.Telemetry;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using PolarisGateway.Validators;
 
 namespace PolarisGateway.Middleware;
 
@@ -30,6 +30,10 @@ public sealed partial class RequestValidationMiddleware(
         var requestTelemetry = new RequestTelemetry();
         requestTelemetry.Start();
         var requestData = await context.GetHttpRequestDataAsync();
+        if (requestData.Headers.TryGetValues("ClientName", out var clientNames))
+        {
+            requestTelemetry.Properties[TelemetryConstants.ClientNameCustomDimensionName] = clientNames.FirstOrDefault(string.Empty);
+        }
 
         var correlationId = Guid.NewGuid();
 

--- a/polaris-pipeline/Common/Middleware/ExceptionHandlingMiddleware.cs
+++ b/polaris-pipeline/Common/Middleware/ExceptionHandlingMiddleware.cs
@@ -69,6 +69,12 @@ public class ExceptionHandlingMiddleware : IFunctionsWorkerMiddleware
                 _logger.LogMethodError(correlationId, httpRequestData.Url.ToString(), message, exception);
                 requestTelemetry.Properties[TelemetryConstants.CorrelationIdCustomDimensionName] = correlationId.ToString();
 
+                // Add ClientName to telemetry if exists in header
+                if (httpRequestData.Headers.TryGetValues("ClientName", out var clientNames))
+                {
+                    requestTelemetry.Properties[TelemetryConstants.ClientNameCustomDimensionName] = clientNames.FirstOrDefault(string.Empty);
+                }
+
                 var newHttpResponse = httpRequestData.CreateResponse(statusCode);
 
                 var errorMessage = ExtractErrorMessage(exception);

--- a/polaris-pipeline/Common/Middleware/RequestTelemetryMiddleware.cs
+++ b/polaris-pipeline/Common/Middleware/RequestTelemetryMiddleware.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Common.Extensions;
 using Common.Telemetry;
+using System.Linq;
 
 namespace Common.Middleware;
 
@@ -21,6 +22,11 @@ public class RequestTelemetryMiddleware(Microsoft.ApplicationInsights.TelemetryC
         {
             await next(context);
             return;
+        }
+
+        if (requestData.Headers.TryGetValues("ClientName", out var clientNames))
+        {
+            requestTelemetry.Properties[TelemetryConstants.ClientNameCustomDimensionName] = clientNames.FirstOrDefault(string.Empty);
         }
 
         var correlationId = Guid.NewGuid();

--- a/polaris-pipeline/Common/Telemetry/TelemetryConstants.cs
+++ b/polaris-pipeline/Common/Telemetry/TelemetryConstants.cs
@@ -12,5 +12,6 @@ namespace Common.Telemetry
         public const string LoadBalancingCookie = "LoadBalancingCookie";
         public const string IsMockUser = "IsMockUser";
         public const string ErrorMessageCustomDimensionName = "ErrorMessage";
+        public const string ClientNameCustomDimensionName = "Client Name";
     }
 }

--- a/polaris-pipeline/coordinator/Middleware/RequestValidationMiddleware.cs
+++ b/polaris-pipeline/coordinator/Middleware/RequestValidationMiddleware.cs
@@ -1,14 +1,15 @@
-﻿using Common.Extensions;
-using Common.Telemetry;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Azure.Functions.Worker.Middleware;
-using System;
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Common.Configuration;
 using Common.Constants;
-using System.Text.RegularExpressions;
-using Microsoft.ApplicationInsights.DataContracts;
+using Common.Extensions;
+using Common.Telemetry;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
 
 namespace coordinator.Middleware;
 
@@ -27,6 +28,12 @@ public sealed partial class RequestValidationMiddleware(Microsoft.ApplicationIns
         {
             await next(context);
             return;
+        }
+
+        // Add ClientName to telemetry if exists in header
+        if (requestData.Headers.TryGetValues("ClientName", out var clientNames))
+        {
+            requestTelemetry.Properties[TelemetryConstants.ClientNameCustomDimensionName] = clientNames.FirstOrDefault(string.Empty);
         }
 
         try


### PR DESCRIPTION
Extract 'ClientName' header from API calls and log on AppInsights