### PR TITLE
Adding ILogger rules to allow logs through AI

### DIFF
--- a/polaris-gateway/ApplicationStartup/Program.cs
+++ b/polaris-gateway/ApplicationStartup/Program.cs
@@ -62,14 +62,13 @@ var host = new HostBuilder()
         }); */
         services.ConfigureLoggerFilterOptions();
 
-        // Configure logging with Application Insights after telemetry service is registered
-        services.AddLogging(builder =>
-        {
-            builder.AddApplicationInsights();
-        });
-
         // Remove server header to satisfy ITHC requirement.
         services.Configure<KestrelServerOptions>(k => k.AddServerHeader = false);
+    })
+    .ConfigureLogging(loggingBuilder =>
+    {
+        // Add Application Insights logging after services are configured
+        loggingBuilder.AddApplicationInsights();
     })
     .Build();
 

--- a/polaris-gateway/ApplicationStartup/Program.cs
+++ b/polaris-gateway/ApplicationStartup/Program.cs
@@ -39,7 +39,6 @@ var host = new HostBuilder()
         });
     })
     .ConfigureOpenApi()
-    .ConfigureLogging(options => options.AddApplicationInsights())
     .ConfigureAppConfiguration(builder => builder.AddConfigurationSettings())
     .ConfigureServices((services) =>
     {
@@ -62,6 +61,12 @@ var host = new HostBuilder()
             telemetryConfiguration.DisableTelemetry = false;
         }); */
         services.ConfigureLoggerFilterOptions();
+
+        // Configure logging with Application Insights after telemetry service is registered
+        services.AddLogging(builder =>
+        {
+            builder.AddApplicationInsights();
+        });
 
         // Remove server header to satisfy ITHC requirement.
         services.Configure<KestrelServerOptions>(k => k.AddServerHeader = false);

--- a/polaris-gateway/ApplicationStartup/Program.cs
+++ b/polaris-gateway/ApplicationStartup/Program.cs
@@ -18,13 +18,6 @@ using System;
 using System.Linq;
 
 var host = new HostBuilder()
-    .ConfigureLogging((context, logging) =>
-        {
-            logging.ClearProviders();  // Remove default providers to avoid duplication
-            logging.AddFilter("Microsoft", LogLevel.Warning);
-            logging.AddFilter("System", LogLevel.Warning);
-            logging.SetMinimumLevel(LogLevel.Information);
-        })
     .ConfigureFunctionsWebApplication(options =>
     {
         options.UseMiddleware<ExceptionHandlingMiddleware>();
@@ -67,11 +60,10 @@ var host = new HostBuilder()
                 .UseAdaptiveSampling(maxTelemetryItemsPerSecond: 20, excludedTypes: "Request;Exception;Event;Trace");
             telemetryConfiguration.DisableTelemetry = false;
         }); */
-       // services.ConfigureLoggerFilterOptions();
+        services.ConfigureLoggerFilterOptions();
 
         // Remove server header to satisfy ITHC requirement.
         services.Configure<KestrelServerOptions>(k => k.AddServerHeader = false);
-        services.AddLogging();
     })
     .Build();
 

--- a/polaris-gateway/ApplicationStartup/Program.cs
+++ b/polaris-gateway/ApplicationStartup/Program.cs
@@ -39,6 +39,7 @@ var host = new HostBuilder()
         });
     })
     .ConfigureOpenApi()
+    .ConfigureLogging(options => options.AddApplicationInsights())
     .ConfigureAppConfiguration(builder => builder.AddConfigurationSettings())
     .ConfigureServices((services) =>
     {

--- a/polaris-gateway/ApplicationStartup/Program.cs
+++ b/polaris-gateway/ApplicationStartup/Program.cs
@@ -18,6 +18,13 @@ using System;
 using System.Linq;
 
 var host = new HostBuilder()
+    .ConfigureLogging((context, logging) =>
+        {
+            logging.ClearProviders();  // Remove default providers to avoid duplication
+            logging.AddFilter("Microsoft", LogLevel.Warning);
+            logging.AddFilter("System", LogLevel.Warning);
+            logging.SetMinimumLevel(LogLevel.Information);
+        })
     .ConfigureFunctionsWebApplication(options =>
     {
         options.UseMiddleware<ExceptionHandlingMiddleware>();
@@ -60,15 +67,11 @@ var host = new HostBuilder()
                 .UseAdaptiveSampling(maxTelemetryItemsPerSecond: 20, excludedTypes: "Request;Exception;Event;Trace");
             telemetryConfiguration.DisableTelemetry = false;
         }); */
-        services.ConfigureLoggerFilterOptions();
+       // services.ConfigureLoggerFilterOptions();
 
         // Remove server header to satisfy ITHC requirement.
         services.Configure<KestrelServerOptions>(k => k.AddServerHeader = false);
-    })
-    .ConfigureLogging(loggingBuilder =>
-    {
-        // Add Application Insights logging after services are configured
-        loggingBuilder.AddApplicationInsights();
+        services.AddLogging();
     })
     .Build();
 

--- a/polaris-gateway/host.json
+++ b/polaris-gateway/host.json
@@ -1,7 +1,6 @@
 {
     "version": "2.0",
     "logging": {
-        "fileLoggingMode": "debugOnly",
         "logLevel": {
             "default": "Trace",
             "Function": "Information",

--- a/polaris-gateway/host.json
+++ b/polaris-gateway/host.json
@@ -2,31 +2,35 @@
     "version": "2.0",
     "logging": {
         "logLevel": {
-            "default": "Trace",
+            "default": "Information",
             "Function": "Information",
             "Host.Aggregator": "Error",
             "Host.Results": "Information",
             "PolarisGateway.Functions.CmsAuthentication.InitiateCookies": "Information"
         },
         "applicationInsights": {
-            "logLevel": {
-                "default": "Information"
+            //"logLevel": {
+            //    "default": "Information"
+            //},
+            "samplingSettings": {
+                "isEnabled": false,
+                "excludedTypes": "Request",
+                "enableLiveMetrics": true,
+                "enableDependencyTracking": true,
+                "enablePerformanceCountersCollection": true,
+                "httpAutoCollectionOptions": {
+                    "enableHttpTriggerExtendedInfoCollection": true,
+                    "enableW3CDistributedTracing": true,
+                    "enableResponseHeaderInjection": true
+                }
             },
-            "enableLiveMetrics": true,
-            "enableDependencyTracking": true,
-            "enablePerformanceCountersCollection": true,
-            "httpAutoCollectionOptions": {
-                "enableHttpTriggerExtendedInfoCollection": true,
-                "enableW3CDistributedTracing": true,
-                "enableResponseHeaderInjection": true
-            }
-        },
-        "extensions": {
-            "http": {
-                "customHeaders": {
-                    "Server": ""
+            "extensions": {
+                "http": {
+                    "customHeaders": {
+                        "Server": ""
+                    }
                 }
             }
         }
     }
-}
+ }

--- a/polaris-gateway/polaris-gateway.csproj
+++ b/polaris-gateway/polaris-gateway.csproj
@@ -14,6 +14,11 @@
 	  <None Remove="Services\HouseKeeping\**" />
 	</ItemGroup>
 	<ItemGroup>
+	  <Content Include="host.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </Content>
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
@@ -33,9 +38,6 @@
 		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 	</ItemGroup>
 	<ItemGroup>
-		<None Update="host.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
 
 		<None Update="local.settings.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -51,4 +53,5 @@
 		<ProjectReference Include="..\DdeiClient\DdeiClient.csproj" />
 		<ProjectReference Include="..\polaris-pipeline\Common\Common.csproj" />
 	</ItemGroup>
+	<ProjectExtensions><VisualStudio><UserProperties host_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
 </Project>

--- a/polaris-pipeline/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/polaris-pipeline/Common/Extensions/ServiceCollectionExtensions.cs
@@ -20,5 +20,36 @@ public static class ServiceCollectionExtensions
             {
                 options.Rules.Remove(toRemove);
             }
+
+            // Add explicit rules to allow logs through to Application Insights in .NET 8 Isolated mode
+            // Without these rules, ILogger messages won't reach App Insights even after removing the restrictive filter
+
+            // Capture all application logs at Information level and above (includes Warning, Error, Critical)
+            options.Rules.Add(new LoggerFilterRule(
+                typeof(ApplicationInsightsLoggerProvider).FullName,
+                null, // All categories
+                LogLevel.Information,
+                null));
+
+            // Reduce noise from Microsoft internal libraries - only capture warnings and above
+            options.Rules.Add(new LoggerFilterRule(
+                typeof(ApplicationInsightsLoggerProvider).FullName,
+                "Microsoft",
+                LogLevel.Warning,
+                null));
+
+            // Ensure host logs are captured at Information level
+            options.Rules.Add(new LoggerFilterRule(
+                typeof(ApplicationInsightsLoggerProvider).FullName,
+                "Host",
+                LogLevel.Information,
+                null));
+
+            // Ensure function execution logs are captured at Information level
+            options.Rules.Add(new LoggerFilterRule(
+                typeof(ApplicationInsightsLoggerProvider).FullName,
+                "Function",
+                LogLevel.Information,
+                null));
         });
 }

--- a/polaris-pipeline/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/polaris-pipeline/Common/Extensions/ServiceCollectionExtensions.cs
@@ -11,8 +11,9 @@ public static class ServiceCollectionExtensions
         services.Configure<LoggerFilterOptions>(options =>
         {
             // See: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=windows#managing-log-levels
-            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs. Application Insights requires an explicit override.
-            // Log levels can also be configured using appsettings.json. For more information, see https://learn.microsoft.com/en-us/azure/azure-monitor/app/worker-service#ilogger-logs
+            // The Application Insights SDK adds a default logging filter that instructs ILogger to capture only Warning and more severe logs.
+            // This filter must be removed to allow host.json log level configuration to take effect in .NET 8 Isolated mode.
+            // Log levels are configured in host.json under logging.applicationInsights.logLevel
             var toRemove = options.Rules
                 .FirstOrDefault(rule => string.Equals(rule.ProviderName, typeof(ApplicationInsightsLoggerProvider).FullName));
 
@@ -20,36 +21,5 @@ public static class ServiceCollectionExtensions
             {
                 options.Rules.Remove(toRemove);
             }
-
-            // Add explicit rules to allow logs through to Application Insights in .NET 8 Isolated mode
-            // Without these rules, ILogger messages won't reach App Insights even after removing the restrictive filter
-
-            // Capture all application logs at Information level and above (includes Warning, Error, Critical)
-            options.Rules.Add(new LoggerFilterRule(
-                typeof(ApplicationInsightsLoggerProvider).FullName,
-                null, // All categories
-                LogLevel.Information,
-                null));
-
-            // Reduce noise from Microsoft internal libraries - only capture warnings and above
-            options.Rules.Add(new LoggerFilterRule(
-                typeof(ApplicationInsightsLoggerProvider).FullName,
-                "Microsoft",
-                LogLevel.Warning,
-                null));
-
-            // Ensure host logs are captured at Information level
-            options.Rules.Add(new LoggerFilterRule(
-                typeof(ApplicationInsightsLoggerProvider).FullName,
-                "Host",
-                LogLevel.Information,
-                null));
-
-            // Ensure function execution logs are captured at Information level
-            options.Rules.Add(new LoggerFilterRule(
-                typeof(ApplicationInsightsLoggerProvider).FullName,
-                "Function",
-                LogLevel.Information,
-                null));
         });
 }


### PR DESCRIPTION
Add explicit rules to allow logs through to Application Insights in .NET 8 Isolated mode without these rules, ILogger messages won't reach App Insights even after removing the restrictive filter