### PR TITLE
Feature/FCT2-18178 Fix ILogger configuration So that logs are sent to AI

### DIFF
--- a/DdeiClient/Clients/MasterDataServiceClient.cs
+++ b/DdeiClient/Clients/MasterDataServiceClient.cs
@@ -1221,6 +1221,7 @@ namespace DdeiClient.Clients
                     Subject = request.Subject,
                     ExistingProducerOrWitnessId = request.ExistingProducerOrWitnessId,
                     NewProducer = request.NewProducer,
+                    Used = request.Used,
                 };
 
                 var data = await client.UpdateExhibitAsync(request.CaseId, request.MaterialId, mdsRequest);

--- a/polaris-gateway/ApplicationStartup/ServiceExtensions.cs
+++ b/polaris-gateway/ApplicationStartup/ServiceExtensions.cs
@@ -46,7 +46,6 @@ public static class ServiceExtensions
         var sp = services.BuildServiceProvider();
         var configuration = sp.GetService<IConfiguration>();
 
-        services.AddSingleton<Microsoft.ApplicationInsights.TelemetryClient, Microsoft.ApplicationInsights.TelemetryClient>();
         services.AddSingleton(configuration);
         services.AddSingleton(_ => new ConfigurationManager<OpenIdConnectConfiguration>(
                 $"https://sts.windows.net/{Environment.GetEnvironmentVariable(OAuthSettings.TenantId)}/.well-known/openid-configuration",

--- a/polaris-gateway/host.json
+++ b/polaris-gateway/host.json
@@ -1,7 +1,6 @@
 {
     "version": "2.0",
     "logging": {
-        "fileLoggingMode": "debugOnly",
         "logLevel": {
             "default": "Trace",
             "Function": "Information",


### PR DESCRIPTION
Remove manually constructed TelemetryClient instance that is registered in DI independently of the one configured by in porgram.cs - AddApplicationInsightsTelemetryWorkerService() with the corrects values. This was causing a DI collision.