### PR TITLE
FCT2-19721 - Fix for Redaction converting PDF to image

### DIFF
--- a/polaris-pipeline/pdf-redactor/Services/DocumentRedaction/Aspose/RedactionImplementations/DirectImplementation.cs
+++ b/polaris-pipeline/pdf-redactor/Services/DocumentRedaction/Aspose/RedactionImplementations/DirectImplementation.cs
@@ -1,26 +1,39 @@
 using Aspose.Pdf;
 using Aspose.Pdf.Annotations;
 
-namespace pdf_redactor.Services.DocumentRedaction.Aspose.RedactionImplementations
+namespace pdf_redactor.Services.DocumentRedaction.Aspose.RedactionImplementations;
+
+public class DirectImplementation : IRedactionImplementation
 {
-    public class DirectImplementation : IRedactionImplementation
+    public void AttachAnnotation(Page page, Rectangle rect)
     {
-        public void AttachAnnotation(Page page, Rectangle rect)
+        var redaction = new RedactionAnnotation(page, rect)
         {
-            var hardAnnotation = new RedactionAnnotation(page, rect)
+            FillColor = Color.Black,
+            Color = Color.Black,
+        };
+
+        page.Annotations.Add(redaction, true);
+    }
+
+    public void FinaliseAnnotations(ref Document document, Guid correlationId)
+    {
+        foreach (Page page in document.Pages)
+        {
+            var redactions = page.Annotations
+                .Where(a => a.AnnotationType == AnnotationType.Redaction)
+                .Cast<RedactionAnnotation>()
+                .ToList();
+
+            foreach (var redaction in redactions)
             {
-                FillColor = Color.Black,
-            };
-
-            page.Annotations.Add(hardAnnotation, true);
-            hardAnnotation.Redact();
+                redaction.Redact();
+            }
         }
+    }
 
-        public void FinaliseAnnotations(ref Document doc, Guid correlationId) { }
-
-        public (ProviderType, string?) GetProviderType()
-        {
-            return (ProviderType.DirectRedaction, null);
-        }
+    public (ProviderType, string?) GetProviderType()
+    {
+        return (ProviderType.DirectRedaction, null);
     }
 }

--- a/polaris-pipeline/pdf-redactor/Services/DocumentRedaction/Aspose/RedactionImplementations/DirectImplementation.cs
+++ b/polaris-pipeline/pdf-redactor/Services/DocumentRedaction/Aspose/RedactionImplementations/DirectImplementation.cs
@@ -16,9 +16,9 @@ public class DirectImplementation : IRedactionImplementation
         page.Annotations.Add(redaction, true);
     }
 
-    public void FinaliseAnnotations(ref Document document, Guid correlationId)
+    public void FinaliseAnnotations(ref Document doc, Guid correlationId)
     {
-        foreach (Page page in document.Pages)
+        foreach (Page page in doc.Pages)
         {
             var redactions = page.Annotations
                 .Where(a => a.AnnotationType == AnnotationType.Redaction)

--- a/polaris-pipeline/pdf-redactor/Services/Extensions/ServiceCollectionExtension.cs
+++ b/polaris-pipeline/pdf-redactor/Services/Extensions/ServiceCollectionExtension.cs
@@ -17,7 +17,7 @@ namespace pdf_redactor.Services.Extensions
             // Aspose-specific services
             services.AddSingleton<IRedactionProvider, AsposeRedactionProvider>();
             services.AddSingleton<ICoordinateCalculator, CoordinateCalculator>();
-            services.AddSingleton<IRedactionImplementation, ImageConversionImplementation>();
+            services.AddSingleton<IRedactionImplementation, DirectImplementation>();
             services.AddSingleton<IDocumentManipulationProvider, AsposeDocumentManipulationProvider>();
             services.Configure<ImageConversionOptions>(configuration.GetSection(ImageConversionOptions.ConfigKey));
         }


### PR DESCRIPTION
Use DirectImplementation Interface instead of ImageConversion. This will not transform PDF to an image, thus allowing user to select text from PDF.