### PR TITLE
FCT2-20956 Ensure that materials not matched with mapping data are set to 'unknown' state

### DIFF
--- a/Cps.Fct.Hk.Ui.Services.Tests/CommunicationServiceTests.cs
+++ b/Cps.Fct.Hk.Ui.Services.Tests/CommunicationServiceTests.cs
@@ -3274,7 +3274,7 @@ public class CommunicationServiceTests
         };
 
         this.apiClientMock
-            .Setup(client => client.GetHistoryEventsAsync(caseId, cmsAuthValues))
+            .Setup(client => client.GetHistoryEventsAsync(caseId, cmsAuthValues, customCancellationToken))
             .ReturnsAsync(historyEvents);
 
         // Act
@@ -3282,7 +3282,7 @@ public class CommunicationServiceTests
 
         // Assert
         Assert.NotNull(result);
-        this.apiClientMock.Verify(client => client.GetHistoryEventsAsync(caseId, cmsAuthValues), Times.Once);
+        this.apiClientMock.Verify(client => client.GetHistoryEventsAsync(caseId, cmsAuthValues, customCancellationToken), Times.Once);
     }
 
     /// <summary>

--- a/Cps.Fct.Hk.Ui.Services.Tests/DocumentTypeMapperTests.cs
+++ b/Cps.Fct.Hk.Ui.Services.Tests/DocumentTypeMapperTests.cs
@@ -81,7 +81,121 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal("Unknown", result.Category);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns correct DocumentTypeInfo when valid string ID is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_ValidStringId_ReturnsCorrectDocumentTypeInfo()
+    {
+        // Arrange
+        string materialType = "1201"; // String representation of a valid documentTypeId
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(materialType);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("ABE", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns "Unknown" values when invalid string ID is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_InvalidStringId_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string invalidMaterialType = "9999"; // String representation of an invalid documentTypeId
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(invalidMaterialType);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns "Unknown" values when non-numeric string is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_NonNumericString_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string nonNumericMaterialType = "InvalidType"; // Non-numeric string
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(nonNumericMaterialType);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns "Unknown" values when empty string is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_EmptyString_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string emptyMaterialType = string.Empty;
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(emptyMaterialType);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapDocumentType"/> returns "Unknown" for zero as document type ID.
+    /// </summary>
+    [Fact]
+    public void MapDocumentType_ZeroId_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        int zeroDocumentTypeId = 0;
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapDocumentType(zeroDocumentTypeId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapDocumentType"/> returns "Unknown" for negative document type ID.
+    /// </summary>
+    [Fact]
+    public void MapDocumentType_NegativeId_ReturnsCorrectOrUnknownDocumentTypeInfo()
+    {
+        // Arrange - negative IDs can be valid in the mapping (e.g., -1, -2, etc.)
+        int negativeDocumentTypeId = -999; // A negative ID that doesn't exist
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapDocumentType(negativeDocumentTypeId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
     /// <summary>

--- a/Cps.Fct.Hk.Ui.Services.Tests/DocumentTypeMapperTests.cs
+++ b/Cps.Fct.Hk.Ui.Services.Tests/DocumentTypeMapperTests.cs
@@ -81,7 +81,7 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
@@ -118,7 +118,7 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
@@ -137,7 +137,7 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
@@ -156,7 +156,7 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
@@ -175,7 +175,7 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
     }
 
@@ -194,8 +194,83 @@ public class DocumentTypeMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("Unknown", result.DocumentType);
-        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
         Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns "Unknown" values when whitespace string is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_WhitespaceString_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string whitespaceMaterialType = "   ";
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(whitespaceMaterialType);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns "Unknown" values when null string is provided.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_NullString_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string? nullMaterialType = null;
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(nullMaterialType!);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Unknown", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
+        Assert.Equal(DocumentTypeGroups.Other, result.Group);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapDocumentType"/> returns correct info for valid negative ID that exists in mapping.
+    /// </summary>
+    [Fact]
+    public void MapDocumentType_ValidNegativeId_ReturnsCorrectDocumentTypeInfo()
+    {
+        // Arrange
+        int validNegativeId = -1; // This is "Correspondence" in the mapping
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapDocumentType(validNegativeId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Correspondence", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.Communication, result.Category);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="DocumentTypeMapper.MapMaterialType"/> returns correct info when string contains leading/trailing spaces but is valid.
+    /// </summary>
+    [Fact]
+    public void MapMaterialType_ValidIdWithSpaces_ReturnsUnknownDocumentTypeInfo()
+    {
+        // Arrange
+        string materialTypeWithSpaces = " 1201 "; // Valid ID with spaces (TryParse should fail)
+
+        // Act
+        DocumentTypeInfo result = this.documentTypeMapper.MapMaterialType(materialTypeWithSpaces);
+
+        // Assert - TryParse handles trimming, so this should succeed
+        Assert.NotNull(result);
+        // Note: int.TryParse actually trims whitespace, so this should return the valid mapping
+        Assert.Equal("ABE", result.DocumentType);
+        Assert.Equal(DocumentTypeCategories.OtherMaterial, result.Category);
     }
 
     /// <summary>

--- a/Cps.Fct.Hk.Ui.Services/DocumentTypeMapper.cs
+++ b/Cps.Fct.Hk.Ui.Services/DocumentTypeMapper.cs
@@ -335,7 +335,7 @@ public class DocumentTypeMapper : IDocumentTypeMapper
     {
         return this.documentTypeMapping.TryGetValue(documentTypeId, out DocumentTypeInfo? info)
             ? info
-            : new DocumentTypeInfo { DocumentType = "Unknown", Category = "Unknown" };
+            : new DocumentTypeInfo { DocumentType = "Unknown", Category = DocumentTypeCategories.OtherMaterial, Group = DocumentTypeGroups.Other };
     }
 
     /// <inheritdoc />
@@ -346,12 +346,12 @@ public class DocumentTypeMapper : IDocumentTypeMapper
         {
             return this.documentTypeMapping.TryGetValue(materialTypeId, out DocumentTypeInfo? info)
                 ? info
-                : new DocumentTypeInfo { DocumentType = "Unknown", Category = "Unknown" };
+                : new DocumentTypeInfo { DocumentType = "Unknown", Category = DocumentTypeCategories.OtherMaterial, Group = DocumentTypeGroups.Other };
         }
         else
         {
             // If the conversion fails, return a default value
-            return new DocumentTypeInfo { DocumentType = "Unknown", Category = "Unknown" };
+            return new DocumentTypeInfo { DocumentType = "Unknown", Category = DocumentTypeCategories.OtherMaterial, Group = DocumentTypeGroups.Other };
         }
     }
 }

--- a/polaris-gateway.tests/Functions/HouseKeeping/GetDocumentTypesTests.cs
+++ b/polaris-gateway.tests/Functions/HouseKeeping/GetDocumentTypesTests.cs
@@ -68,7 +68,7 @@ public class GetDocumentTypesTests
     }
 
     /// <summary>
-    /// Tests that the function returns an unauthorized error when unauthorized exception is thrown.
+    /// Tests that the function returns OK response when the request is processed successfully.
     /// </summary>
     [Fact]
     public void Run_ReturnsOkResponse_WhenRequestIsProcessedSuccessfully()
@@ -103,6 +103,188 @@ public class GetDocumentTypesTests
             log.Message != null && log.Message.Contains($"{LoggingConstants.HskUiLogPrefix} Milestone: caseId [123] GetDocumentTypes function completed"));
 
         mockDocumentTypeMapper.Verify(svc => svc.GetDocumentTypesWithClassificationGroup(), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that the function returns OK response with empty list when document type mapper returns empty list.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsOkResponseWithEmptyList_WhenDocumentTypeMapperReturnsEmptyList()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        var emptyResponse = new List<DocumentTypeGroup>();
+
+        mockDocumentTypeMapper
+           .Setup(svc => svc.GetDocumentTypesWithClassificationGroup())
+          .Returns(emptyResponse);
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 123);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+
+        var resultList = Assert.IsType<List<DocumentTypeGroup>>(okResult.Value);
+        Assert.Empty(resultList);
+
+        mockDocumentTypeMapper.Verify(svc => svc.GetDocumentTypesWithClassificationGroup(), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that the function returns OK response with multiple document types grouped correctly.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsOkResponseWithMultipleGroups_WhenDocumentTypeMapperReturnsMultipleGroups()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        var response = new List<DocumentTypeGroup>()
+        {
+            new () { Id = 1031, Name = "MG11", Group = "Statement", Category = "Statement" },
+            new () { Id = 1030, Name = "Other Exhibit", Group = "Exhibit", Category = "Exhibit" },
+            new () { Id = 1066, Name = "MG00", Group = "MG Form", Category = "MG Form" },
+            new () { Id = 1200, Name = "Other Material", Group = "Other", Category = "Other Material" },
+        };
+
+        mockDocumentTypeMapper
+           .Setup(svc => svc.GetDocumentTypesWithClassificationGroup())
+          .Returns(response);
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 456);
+
+        // Assert
+        OkObjectResult okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(okResult.Value);
+
+        var resultList = (IReadOnlyList<DocumentTypeGroup>)okResult.Value;
+        Assert.Equal(4, resultList.Count);
+        Assert.Contains(resultList, dt => dt.Group == "Statement");
+        Assert.Contains(resultList, dt => dt.Group == "Exhibit");
+        Assert.Contains(resultList, dt => dt.Group == "MG Form");
+        Assert.Contains(resultList, dt => dt.Group == "Other");
+
+        mockDocumentTypeMapper.Verify(svc => svc.GetDocumentTypesWithClassificationGroup(), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that the function returns bad request when invalid case ID is provided.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsBadRequest_WhenInvalidCaseIdIsProvided()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 0);
+
+        // Assert
+        BadRequestObjectResult badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
+        Assert.Contains("Invalid case Id", badRequestResult.Value?.ToString());
+
+        mockDocumentTypeMapper.Verify(svc => svc.GetDocumentTypesWithClassificationGroup(), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that the function returns bad request when negative case ID is provided.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsBadRequest_WhenNegativeCaseIdIsProvided()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, -1);
+
+        // Assert
+        BadRequestObjectResult badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
+
+        mockDocumentTypeMapper.Verify(svc => svc.GetDocumentTypesWithClassificationGroup(), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that the function returns unprocessable entity when invalid operation exception is thrown by document type mapper.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsUnprocessableEntity_WhenInvalidOperationExceptionIsThrown()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        mockDocumentTypeMapper
+             .Setup(svc => svc.GetDocumentTypesWithClassificationGroup())
+            .Throws(new InvalidOperationException("Invalid operation"));
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 123);
+
+        // Assert
+        UnprocessableEntityObjectResult unprocessableResult = Assert.IsType<UnprocessableEntityObjectResult>(result);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, unprocessableResult.StatusCode);
+        Assert.Contains("Invalid operation", unprocessableResult.Value?.ToString());
+
+        Assert.Contains(mockLogger.Logs, log =>
+            log.LogLevel == LogLevel.Error &&
+            log.Message != null && log.Message.Contains($"{LoggingConstants.HskUiLogPrefix} GetDocumentTypes function encountered an invalid operation error"));
+    }
+
+    /// <summary>
+    /// Tests that the function returns unprocessable entity when not supported exception is thrown by document type mapper.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsUnprocessableEntity_WhenNotSupportedExceptionIsThrown()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        mockDocumentTypeMapper
+             .Setup(svc => svc.GetDocumentTypesWithClassificationGroup())
+            .Throws(new NotSupportedException("Not supported"));
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 123);
+
+        // Assert
+        UnprocessableEntityObjectResult unprocessableResult = Assert.IsType<UnprocessableEntityObjectResult>(result);
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, unprocessableResult.StatusCode);
+        Assert.Contains("GetDocumentTypes error: Not supported", unprocessableResult.Value?.ToString());
+
+        Assert.Contains(mockLogger.Logs, log =>
+            log.LogLevel == LogLevel.Error &&
+            log.Message != null && log.Message.Contains($"{LoggingConstants.HskUiLogPrefix} GetDocumentTypes function encountered an unsupported content type error"));
+    }
+
+    /// <summary>
+    /// Tests that the function returns internal server error when generic exception is thrown by document type mapper.
+    /// </summary>
+    [Fact]
+    public void Run_ReturnsInternalServerError_WhenGenericExceptionIsThrown()
+    {
+        // Arrange
+        Mock<HttpRequest> mockRequest = SetUpMockRequest();
+
+        mockDocumentTypeMapper
+             .Setup(svc => svc.GetDocumentTypesWithClassificationGroup())
+            .Throws(new Exception("Unexpected error"));
+
+        // Act
+        IActionResult result = sutGetDocumentTypes.Run(mockRequest.Object, 123);
+
+        // Assert
+        StatusCodeResult statusCodeResult = Assert.IsType<StatusCodeResult>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusCodeResult.StatusCode);
+
+        Assert.Contains(mockLogger.Logs, log =>
+            log.LogLevel == LogLevel.Error &&
+            log.Message != null && log.Message.Contains($"{LoggingConstants.HskUiLogPrefix} GetDocumentTypes function encountered an error"));
     }
 
     private static Mock<HttpRequest> SetUpMockRequest()


### PR DESCRIPTION
Ensure that materials not matched with mapping data are set to 'unknown' state so that they can be reclassified
Add missing unt tests